### PR TITLE
Add reflection config for JSON token classes

### DIFF
--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/reflect-config.json
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/reflect-config.json
@@ -124,16 +124,6 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
-  "name":"com.google.api.client.json.GenericJson",
-  "allDeclaredFields":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"com.google.api.client.util.GenericData",
-  "allDeclaredFields":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
   "name":"com.google.auth.oauth2.GoogleCredentials"
 },
 {
@@ -650,5 +640,54 @@
   "name":"sun.security.provider.certpath.PKIXMasterCertPathValidator",
   "allDeclaredConstructors" : true,
   "allDeclaredMethods" : true
+},
+
+{
+  "name": "com.google.api.client.json.GenericJson",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.json.webtoken.JsonWebToken",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.json.webtoken.JsonWebToken$Header",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.json.webtoken.JsonWebToken$Payload",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.util.GenericData",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.http.UrlEncodedContent",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.json.webtoken.JsonWebSignature$Header",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "com.google.api.client.json.webtoken.JsonWebSignature",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
 }
 ]


### PR DESCRIPTION
Adds the JSON token classes to reflection config to enable correct creation of authentication tokens when using service account authentication.

This change will be verified once I merge in and then #6 will start working.