### PR TITLE
Modify configs to support grpc-netty-shaded

### DIFF
--- a/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
@@ -10,9 +10,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <properties>
-    <graalvm.version>20.1.0</graalvm.version>
-  </properties>
 
   <artifactId>google-cloud-graalvm-pubsub-sample</artifactId>
 
@@ -31,41 +28,23 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.grpc</groupId>
-          <artifactId>grpc-netty-shaded</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <!-- Remove the version after libraries-bom is updated to offer this version -->
+      <version>1.32.1</version>
     </dependency>
 
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.31.Final</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>4.1.51.Final</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>9.0.0</version>
+        <version>10.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -130,8 +109,6 @@
                 -H:EnableURLProtocols=http,https
                 -H:+TraceClassInitialization
                 --report-unsupported-elements-at-runtime
-                --initialize-at-build-time=org.conscrypt
-                --initialize-at-run-time=io.netty.handler.ssl.OpenSsl,io.netty.handler.ssl.OpenSslContext,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.internal.tcnative.CertificateVerifier,io.netty.internal.tcnative.SSL,io.netty.internal.tcnative.SSLPrivateKeyMethod
                 --enable-all-security-services
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
-      <!-- Remove the version after libraries-bom is updated to offer this version -->
+      <!-- Remove this dep after libraries-bom is updated to offer this version -->
       <version>1.32.1</version>
     </dependency>
 

--- a/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
@@ -29,18 +29,17 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty-shaded</artifactId>
-      <!-- Remove this dep after libraries-bom is updated to offer this version -->
-      <version>1.32.1</version>
-    </dependency>
-
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <!-- Remove this dep after libraries-bom is updated to offer this version -->
+        <version>1.32.1</version>
+      </dependency>
+
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>

--- a/google-cloud-graalvm-support/pom.xml
+++ b/google-cloud-graalvm-support/pom.xml
@@ -11,5 +11,12 @@
 
   <artifactId>google-cloud-graalvm-support</artifactId>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.graalvm.nativeimage</groupId>
+      <artifactId>svm</artifactId>
+      <version>${graalvm.version}</version>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/google-cloud-graalvm-support/pom.xml
+++ b/google-cloud-graalvm-support/pom.xml
@@ -11,12 +11,4 @@
 
   <artifactId>google-cloud-graalvm-support</artifactId>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.graalvm.nativeimage</groupId>
-      <artifactId>svm</artifactId>
-      <version>${graalvm.version}</version>
-    </dependency>
-  </dependencies>
-
 </project>

--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/jni-config.json
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/jni-config.json
@@ -1,10 +1,10 @@
 [
 {
-  "name":"io.netty.handler.ssl.ReferenceCountedOpenSslContext$AbstractCertificateVerifier",
+  "name":"io.grpc.netty.shaded.io.netty.handler.ssl.ReferenceCountedOpenSslContext$AbstractCertificateVerifier",
   "methods":[{"name":"verify","parameterTypes":["long","byte[][]","java.lang.String"] }]
 },
 {
-  "name": "io.netty.channel.ChannelException",
+  "name": "io.grpc.netty.shaded.io.netty.channel.ChannelException",
   "allDeclaredMethods": true,
   "allDeclaredFields": true
 },
@@ -40,7 +40,7 @@
   "allDeclaredConstructors":true
 },
 {
-  "name": "io.netty.channel.DefaultFileRegion",
+  "name": "io.grpc.netty.shaded.io.netty.channel.DefaultFileRegion",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
@@ -57,86 +57,149 @@
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
+
 {
-  "name": "io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods",
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.NativeStaticallyReferencedJniMethods",
+  "allDeclaredMethods": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.epoll.Native",
+  "allDeclaredMethods": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.LimitsStaticallyReferencedJniMethods",
+  "allDeclaredMethods": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods",
+  "allDeclaredMethods": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray",
+  "allDeclaredClasses" : true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.epoll.NativeDatagramPacketArray$NativeDatagramPacket",
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.epoll.LinuxSocket",
+  "allDeclaredMethods":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.FileDescriptor",
+  "methods": [
+    { "name": "<init>", "parameterTypes": [] }
+  ],
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.Socket",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
 {
-  "name": "io.netty.internal.tcnative.Library",
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.DatagramSocketAddress",
+  "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
 {
-  "name": "io.netty.internal.tcnative.Buffer",
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.Buffer",
+  "allDeclaredMethods":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.channel.unix.PeerCredentials",
+  "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
 {
-  "name": "io.netty.internal.tcnative.SSL",
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.NativeStaticallyReferencedJniMethods",
+  "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
 },
-  {
-    "name": "io.netty.internal.tcnative.SSLContext",
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.SSLTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.CertificateCallbackTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.CertificateVerifierTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.Library",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.Buffer",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSL",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLContext",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLSession",
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateCallbackTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifierTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
 
-  {
-    "name": "io.netty.internal.tcnative.CertificateVerifier",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.CertificateVerifier",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodSignTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
 
-  {
-    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethod",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-  {
-    "name": "io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
-    "allDeclaredFields":true,
-    "allDeclaredMethods":true,
-    "allDeclaredConstructors":true
-  },
-
-  {
-    "name": "io.netty.internal.tcnative.SSLSession"
-  },
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
+{
+  "name": "io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethodDecryptTask",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "allDeclaredConstructors":true
+},
 {
   "name":"java.lang.ClassLoader",
   "methods":[

--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/reflect-config.json
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/reflect-config.json
@@ -4,46 +4,28 @@
   "methods":[{"name":"<init>","parameterTypes":["long","int"] }]
 },
 {
-  "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
+  "name": "io.grpc.netty.shaded.io.netty.channel.socket.nio.NioSocketChannel",
   "methods": [
     { "name": "<init>", "parameterTypes": [] }
   ]
 },
 {
-  "name": "io.netty.channel.socket.nio.NioSocketChannel",
-  "methods": [
-    { "name": "<init>", "parameterTypes": [] }
-  ]
-},
-{
-  "name":"io.netty.handler.codec.ByteToMessageDecoder",
+  "name":"io.grpc.netty.shaded.io.netty.handler.codec.ByteToMessageDecoder",
   "methods":[
-    {"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
-    {"name":"userEventTriggered","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
+    {"name":"channelRead","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
+    {"name":"userEventTriggered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
   ]
 },
 {
-  "name" : "io.netty.util.internal.NativeLibraryUtil",
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.NativeLibraryUtil",
   "methods": [
     { "name": "loadLibrary", "parameterTypes": ["java.lang.String", "boolean"] }
   ]
 },
 {
-  "name": "io.netty.buffer.AbstractByteBufAllocator",
+  "name": "io.grpc.netty.shaded.io.netty.buffer.AbstractByteBufAllocator",
   "allDeclaredConstructors" : true,
   "allDeclaredMethods" : true
-},
-{
-  "name":"sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"sun.security.ssl.SSLContextImpl",
-  "fields":[{"name":"trustManager", "allowUnsafeAccess":true}]
-},
-{
-  "name":"sun.security.ssl.SSLContextImpl$TLSContext",
-  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"javax.net.ssl.SSLContext",
@@ -54,16 +36,40 @@
   "methods":[{"name":"getUnsafe","parameterTypes":[] }]
 },
 {
-  "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
-  "fields":[{"name":"producerIndex", "allowUnsafeAccess":true}]
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+  "fields": [
+    {"name": "producerIndex", "allowUnsafeAccess": true}
+  ]
 },
 {
-  "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
-  "fields":[{"name":"producerLimit", "allowUnsafeAccess":true}]
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+  "fields": [
+    {"name": "producerLimit", "allowUnsafeAccess": true}
+  ]
 },
 {
-  "name":"io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
-  "fields":[{"name":"consumerIndex", "allowUnsafeAccess":true}]
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+  "fields": [
+    {"name": "consumerIndex", "allowUnsafeAccess": true}
+  ]
+},
+{
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+  "fields": [
+    {"name": "producerIndex", "allowUnsafeAccess": true}
+  ]
+},
+{
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+  "fields": [
+    {"name": "producerLimit", "allowUnsafeAccess": true}
+  ]
+},
+{
+  "name" : "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+  "fields": [
+    {"name": "consumerIndex", "allowUnsafeAccess": true}
+  ]
 },
 {
   "name":"sun.misc.Unsafe",
@@ -330,102 +336,161 @@
   "methods":[{"name":"newBuilder","parameterTypes":[] }]
 },
 {
-  "name":"io.netty.channel.ChannelDuplexHandler",
+  "name":"io.grpc.netty.shaded.io.netty.channel.ChannelDuplexHandler",
   "allDeclaredMethods" : true,
   "methods":[
-    {"name":"bind","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"close","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"connect","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"deregister","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"disconnect","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"flush","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"read","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"write","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object","io.netty.channel.ChannelPromise"] }
+    {"name":"bind","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"close","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"connect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"deregister","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"disconnect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"flush","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"read","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"write","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] }
   ]
 },
 {
-  "name":"io.netty.channel.ChannelInboundHandlerAdapter",
+  "name":"io.grpc.netty.shaded.io.grpc.netty.AbstractNettyHandler",
   "methods":[
-    {"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
-    {"name":"channelReadComplete","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRegistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelUnregistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelWritabilityChanged","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"exceptionCaught","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
-    {"name":"userEventTriggered","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
+    {"name":"channelActive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"exceptionCaught","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] }
   ]
 },
 {
-  "name":"io.netty.channel.DefaultChannelPipeline$HeadContext",
+  "name":"io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler",
   "methods":[
-    {"name":"bind","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
-    {"name":"channelReadComplete","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRegistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelUnregistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelWritabilityChanged","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"close","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"connect","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"deregister","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"disconnect","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"exceptionCaught","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
-    {"name":"flush","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"read","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"userEventTriggered","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
-    {"name":"write","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object","io.netty.channel.ChannelPromise"] }
+    {"name":"channelInactive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"close","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"write","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] }
   ]
 },
 {
-  "name":"io.netty.channel.DefaultChannelPipeline$TailContext",
+  "name":"io.grpc.netty.shaded.io.netty.channel.ChannelInboundHandlerAdapter",
   "methods":[
-    {"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRead","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
-    {"name":"channelReadComplete","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelRegistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelUnregistered","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelWritabilityChanged","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"exceptionCaught","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
-    {"name":"userEventTriggered","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
+    {"name":"channelActive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelInactive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRead","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
+    {"name":"channelReadComplete","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRegistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelUnregistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelWritabilityChanged","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"exceptionCaught","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
+    {"name":"userEventTriggered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
   ]
 },
 {
-  "name":"io.netty.util.ReferenceCountUtil",
+  "name":"io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$GrpcNegotiationHandler",
+  "allDeclaredMethods" : true
+},
+{
+  "name":"io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$ProtocolNegotiationHandler",
+  "allDeclaredMethods" : true
+},
+{
+  "name":"io.grpc.netty.shaded.io.grpc.netty.ProtocolNegotiators$WaitUntilActiveHandler",
+  "allDeclaredMethods" : true
+},
+{
+  "name":"io.grpc.netty.shaded.io.grpc.netty.WriteBufferingAndExceptionHandler",
+  "allDeclaredMethods" : true
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$HeadContext",
+  "methods":[
+    {"name":"bind","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"channelActive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelInactive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRead","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
+    {"name":"channelReadComplete","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRegistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelUnregistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelWritabilityChanged","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"close","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"connect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"deregister","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"disconnect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"exceptionCaught","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
+    {"name":"flush","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"read","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"userEventTriggered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
+    {"name":"write","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] }
+  ]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.DefaultChannelPipeline$TailContext",
+  "methods":[
+    {"name":"channelActive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelInactive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRead","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] },
+    {"name":"channelReadComplete","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelRegistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelUnregistered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelWritabilityChanged","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"exceptionCaught","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
+    {"name":"userEventTriggered","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object"] }
+  ]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.util.ReferenceCountUtil",
   "allDeclaredMethods":true
 },
 {
-  "name":"io.netty.handler.codec.http2.Http2ConnectionHandler",
+  "name":"io.grpc.netty.shaded.io.netty.handler.codec.http2.Http2ConnectionHandler",
   "methods":[
-    {"name":"bind","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"channelReadComplete","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelWritabilityChanged","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"connect","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"deregister","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"disconnect","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"flush","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"read","parameterTypes":["io.netty.channel.ChannelHandlerContext"] }
+    {"name":"bind","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"channelReadComplete","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelWritabilityChanged","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"connect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"deregister","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"disconnect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"flush","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"read","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] }
   ]
 },
 {
-  "name":"io.netty.handler.ssl.SslHandler",
+  "name":"io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler",
   "methods":[
-    {"name":"bind","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"channelActive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelInactive","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"channelReadComplete","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"close","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"connect","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.netty.channel.ChannelPromise"] },
-    {"name":"deregister","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"disconnect","parameterTypes":["io.netty.channel.ChannelHandlerContext","io.netty.channel.ChannelPromise"] },
-    {"name":"exceptionCaught","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
-    {"name":"flush","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"read","parameterTypes":["io.netty.channel.ChannelHandlerContext"] },
-    {"name":"write","parameterTypes":["io.netty.channel.ChannelHandlerContext","java.lang.Object","io.netty.channel.ChannelPromise"] }
+    {"name":"bind","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"channelActive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelInactive","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"channelReadComplete","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"close","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"connect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.net.SocketAddress","java.net.SocketAddress","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"deregister","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"disconnect","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] },
+    {"name":"exceptionCaught","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Throwable"] },
+    {"name":"flush","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"read","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext"] },
+    {"name":"write","parameterTypes":["io.grpc.netty.shaded.io.netty.channel.ChannelHandlerContext","java.lang.Object","io.grpc.netty.shaded.io.netty.channel.ChannelPromise"] }
   ]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.Epoll",
+  "methods":[{"name":"isAvailable","parameterTypes":[] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup",
+  "methods":[{"name":"<init>","parameterTypes":["int","java.util.concurrent.ThreadFactory"] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.EpollServerSocketChannel",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.grpc.netty.shaded.io.netty.channel.epoll.EpollSocketChannel",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.TrustManagerFactoryImpl$PKIXFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.ssl.SSLContextImpl",
+  "fields":[{"name":"trustManager", "allowUnsafeAccess":true}]
+},
+{
+  "name":"sun.security.ssl.SSLContextImpl$TLSContext",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"sun.security.provider.X509Factory",
@@ -615,5 +680,15 @@
   "allDeclaredConstructors": true,
   "allDeclaredMethods": true,
   "allDeclaredFields": true
+},
+{
+  "name": "java.lang.management.ManagementFactory",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true
+},
+{
+  "name": "java.lang.management.RuntimeMXBean",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true
 }
 ]

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+
+    <graalvm.version>20.1.0</graalvm.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Modify configurations to support `grpc-netty-shaded`.

The pom file for the sample is now a lot more simplified: https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/compare/use-netty-shaded?expand=1#diff-bd6c1dc3b6eccc9a9c14673eee04261e

I tried to support both non-shaded and shaded versions of `grpc-netty` but it was a bit too complicated for now. I think the first iteration of the project should just support `grpc-netty-shaded` which is what is inherited by the client libraries.