### PR TITLE
Add sample using the Trace Client Libraries

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         cd google-cloud-graalvm-samples
         java -jar google-cloud-graalvm-pubsub-sample/target/google-cloud-graalvm-pubsub-sample-1.0.0-SNAPSHOT.jar
+        java -jar trace-sample/target/trace-sample-1.0.0-SNAPSHOT.jar
 
   graal-java-build:
     runs-on: ubuntu-latest
@@ -82,3 +83,4 @@ jobs:
       run: |
         cd google-cloud-graalvm-samples
         ./google-cloud-graalvm-pubsub-sample/target/com.example.pubsubsampleapplication
+        ./trace-sample/target/com.example.tracesampleapplication

--- a/google-cloud-graalvm-samples/pom.xml
+++ b/google-cloud-graalvm-samples/pom.xml
@@ -14,6 +14,7 @@
 
   <modules>
     <module>google-cloud-graalvm-pubsub-sample</module>
+    <module>trace-sample</module>
   </modules>
 
   <build>

--- a/google-cloud-graalvm-samples/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/trace-sample/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>google-cloud-graalvm-samples</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>trace-sample</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-graalvm-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-trace</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>11.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <mainClass>com.example.TraceSampleApplication</mainClass>
+              <classpathPrefix>dependency-jars/</classpathPrefix>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.directory}/dependency-jars/
+              </outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>graal</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>native-image-maven-plugin</artifactId>
+            <version>${graalvm.version}</version>
+            <configuration>
+              <mainClass>com.example.TraceSampleApplication</mainClass>
+              <buildArgs>
+                --no-fallback
+                --no-server
+                -H:+AllowIncompleteClasspath
+                -H:+ReportExceptionStackTraces
+                -H:EnableURLProtocols=http,https
+                -H:+TraceClassInitialization
+                --report-unsupported-elements-at-runtime
+                --enable-all-security-services
+              </buildArgs>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>native-image</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/google-cloud-graalvm-samples/trace-sample/src/main/java/com/example/TraceSampleApplication.java
+++ b/google-cloud-graalvm-samples/trace-sample/src/main/java/com/example/TraceSampleApplication.java
@@ -53,7 +53,12 @@ public class TraceSampleApplication {
 
     try {
       // This checks Cloud trace for the new trace that was just created.
-      GetTraceRequest getTraceRequest = createGetTraceRequest(traceId);
+      GetTraceRequest getTraceRequest =
+          GetTraceRequest.newBuilder()
+              .setProjectId(PROJECT_ID)
+              .setTraceId(traceId)
+              .build();
+
       Trace trace = traceServiceClient.getTrace(getTraceRequest);
 
       System.out.println("Retrieved trace: " + trace.getTraceId());
@@ -67,15 +72,6 @@ public class TraceSampleApplication {
           + "Please check https://console.cloud.google.com/traces/traces to "
           + "find your trace in the traces viewer.");
     }
-  }
-
-  private static GetTraceRequest createGetTraceRequest(String traceId) {
-    GetTraceRequest request =
-        GetTraceRequest.newBuilder()
-            .setProjectId(PROJECT_ID)
-            .setTraceId(traceId)
-            .build();
-    return request;
   }
 
   private static PatchTracesRequest createPatchTraceRequest(String traceId) {

--- a/google-cloud-graalvm-samples/trace-sample/src/main/java/com/example/TraceSampleApplication.java
+++ b/google-cloud-graalvm-samples/trace-sample/src/main/java/com/example/TraceSampleApplication.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.trace.v1.TraceServiceClient;
+import com.google.devtools.cloudtrace.v1.GetTraceRequest;
+import com.google.devtools.cloudtrace.v1.PatchTracesRequest;
+import com.google.devtools.cloudtrace.v1.Trace;
+import com.google.devtools.cloudtrace.v1.TraceSpan;
+import com.google.devtools.cloudtrace.v1.Traces;
+import com.google.protobuf.Timestamp;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Sample application demonstrating using the Google Trace client libraries.
+ */
+public class TraceSampleApplication {
+
+  private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
+
+  /**
+   * Runs basic methods in the Trace client libraries.
+   */
+  public static void main(String[] args) throws IOException, InterruptedException {
+    TraceServiceClient traceServiceClient = TraceServiceClient.create();
+
+    // Create a trace in the current project.
+    String traceId = UUID.randomUUID().toString().replaceAll("-", "");
+    PatchTracesRequest createRequest = createPatchTraceRequest(traceId);
+    traceServiceClient.patchTraces(createRequest);
+
+    // Wait for the trace to be populated in Cloud Trace.
+    System.out.println("Wait some time for the Trace to be populated.");
+    Thread.sleep(3000);
+
+    try {
+      // This checks Cloud trace for the new trace that was just created.
+      GetTraceRequest getTraceRequest = createGetTraceRequest(traceId);
+      Trace trace = traceServiceClient.getTrace(getTraceRequest);
+
+      System.out.println("Retrieved trace: " + trace.getTraceId());
+      System.out.println("It has the following spans: ");
+      for (TraceSpan span : trace.getSpansList()) {
+        System.out.println("Span: " + span.getName());
+      }
+    } catch (NotFoundException e) {
+      System.out.println("We didn't find the trace: " + traceId + ". "
+          + "This is usually because we did not wait long enough. "
+          + "Please check https://console.cloud.google.com/traces/traces to "
+          + "find your trace in the traces viewer.");
+    }
+  }
+
+  private static GetTraceRequest createGetTraceRequest(String traceId) {
+    GetTraceRequest request =
+        GetTraceRequest.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setTraceId(traceId)
+            .build();
+    return request;
+  }
+
+  private static PatchTracesRequest createPatchTraceRequest(String traceId) {
+    long currentTime = Instant.now().toEpochMilli() / 1000;
+
+    Trace trace = Trace.newBuilder()
+        .setProjectId(PROJECT_ID)
+        .setTraceId(traceId)
+        .addSpans(
+            TraceSpan.newBuilder()
+                .setSpanId(1)
+                .setName("graalvm-trace-sample-test")
+                .setStartTime(Timestamp.newBuilder().setSeconds(currentTime - 5))
+                .setEndTime(Timestamp.newBuilder().setSeconds(currentTime)))
+        .build();
+
+    PatchTracesRequest request =
+        PatchTracesRequest.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setTraces(Traces.newBuilder().addTraces(trace))
+            .build();
+
+    return request;
+  }
+}


### PR DESCRIPTION
Add another sample using the Trace Client libraries.

Note that this worked out of the box without any config modifications, but this by itself is not too useful it seems; this trace library is a bit low-level and people would likely use it through opencensus or our spring-cloud-gcp-starter-trace. 