### PR TITLE
Upgrade libraries bom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This dependency contains the GraalVM configurations (reflection config, native c
 
 ### Client Library Versions
 
-To get your application working with GraalVM compilation, you will also have to ensure that the client library versions in your project are supported by your chosen version of `google-cloud-graalvm-support`.
+To compile with GraalVM (native-image), ensure the client library version in your project is supported by `google-cloud-graalvm-support`.
 
 | GraalVM Support version | *`libraries-bom` version | `grpc-netty-shaded` version |
 |-------------------------|:-------------------------|-----------------------------|
@@ -46,11 +46,11 @@ The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well s
 
 This project should support many Java Google Client Libraries out-of-the-box.
 
-Our project has [code samples](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples) demonstrating compatibility with the following APIs:
+Our project has [code samples](./google-cloud-graalvm-samples) demonstrating compatibility with the following APIs:
 
 | Google Cloud Service    | Sample Link              | 
 |-------------------------|--------------------------|
-| [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [google-cloud-graalvm-pubsub-sample](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample) |
+| [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [google-cloud-graalvm-pubsub-sample](./google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample) |
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,6 @@ To get your application working with GraalVM compilation, you will also have to 
 **NOTE:** Most users typically manage their client library versions using the [Cloud Libraries Bill of Materials](https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM) (`libraries-bom`).
 The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well so you don't have to manage it yourself.
 
-```
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>libraries-bom</artifactId>
-            <version>11.0.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-```
-
 ## Supported Libraries
 
 This project should support many Java Google Client Libraries out-of-the-box.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,11 @@ The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well s
 
 This project should support many Java Google Client Libraries out-of-the-box.
 
-Our project has code samples demonstrating compatibility with the following APIs:
+Our project has [code samples](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples) demonstrating compatibility with the following APIs:
 
-* [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub)
-
-## Samples
-
-Sample projects can be found in the [google-cloud-graalvm-samples](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples) directory.
+| Google Cloud Service    | Sample Link              | 
+|-------------------------|--------------------------|
+| [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [google-cloud-graalvm-pubsub-sample](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample) |
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well s
 
 ## Supported Libraries
 
-This project should support many Java Google Client Libraries out-of-the-box.
-
-Our project has [code samples](./google-cloud-graalvm-samples) demonstrating compatibility with the following APIs:
+The following Google Cloud Platform client libraries are currently supported:
 
 | Google Cloud Service    | Sample Link              | 
 |-------------------------|--------------------------|
 | [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [google-cloud-graalvm-pubsub-sample](./google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample) |
+
+Additional API compatibility is in active development.
+
+Please also consult the project [samples applications directory](./google-cloud-graalvm-samples) for the full range of code samples.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -31,31 +31,43 @@ After adding the snapshots repository, you can add the `google-cloud-graalvm-sup
 
 This dependency contains the GraalVM configurations (reflection config, native call config) to provide out-of-the-box support for native-image compilation of applications depending on the Google Java Client Libraries.
 
-### Note on grpc-netty-shaded version
+### Client Library Versions
 
-As an additional step, you will also need to override the version of `grpc-netty-shaded` to version `1.32.1` (or later):
+To get your application working with GraalVM compilation, you will also have to ensure that the client library versions in your project are supported by your chosen version of `google-cloud-graalvm-support`.
+
+| GraalVM Support version | *`libraries-bom` version | `grpc-netty-shaded` version |
+|-------------------------|:-------------------------|-----------------------------|
+| `1.0.0-SNAPSHOT`        | `>= 11.0.0`              | `>= 1.32.1`                 |
+
+**NOTE:** Most users typically manage their client library versions using the [Cloud Libraries Bill of Materials](https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM) (`libraries-bom`).
+The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well so you don't have to manage it yourself.
 
 ```
-  <dependencyManagement>
+<dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-netty-shaded</artifactId>
-        <version>1.32.1</version>
-      </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>libraries-bom</artifactId>
+            <version>11.0.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
+</dependencyManagement>
 ```
 
-The Java client libraries import this dependency to your project automatically as a transitive dependency.
-The latest version of `grpc-netty-shaded` contains a patch to enable native image compilation, so this version must be (temporarily) manually upgraded for native image compilation to work.
+## Supported Libraries
+
+This project should support many Java Google Client Libraries out-of-the-box.
+
+Our project has code samples demonstrating compatibility with the following APIs:
+
+* [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub)
 
 ## Samples
 
 Sample projects can be found in the [google-cloud-graalvm-samples](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/tree/master/google-cloud-graalvm-samples) directory.
 
-## Supported Libraries
+## Questions
 
-The project currently supports the following Google Client Libraries:
-
-* [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub)
+Please report any issues and questions to our [Github Issue Tracker](https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/issues).

--- a/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample/pom.xml
@@ -34,16 +34,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-netty-shaded</artifactId>
-        <!-- Remove this dep after libraries-bom is updated to offer this version -->
-        <version>1.32.1</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>10.1.0</version>
+        <version>11.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade the `libraries-bom` version to `11.0.0` so users don't need to override grpc-netty-shaded version.