### PR TITLE
Move setup instructions docs to samples-parent directory

### DIFF
--- a/google-cloud-graalvm-samples/README.md
+++ b/google-cloud-graalvm-samples/README.md
@@ -1,0 +1,40 @@
+# Google Cloud GraalVM Samples
+
+This directory contains code samples that depend on the [Google Java Client Libraries](https://github.com/googleapis/google-cloud-java) and are compatible with GraalVM native image compilation.
+
+## Setup Instructions
+
+You will need to follow these prerequisite steps in order to run these samples:
+
+1. If you have not already, [create a Google Cloud Platform Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project). 
+
+2. Install the [Google Cloud SDK](https://cloud.google.com/sdk/) which will allow you to run the sample with your project's credentials.
+
+    Once installed, log in with Application Default Credentials using the following command:
+    
+    ```
+    gcloud auth application-default login
+    ```
+   
+    **Note:** Authenticating with Application Default Credentials is convenient to use during development, but we recommend [alternate methods of authentication](https://cloud.google.com/docs/authentication/production) during production use.
+    
+3. Install the GraalVM compiler.
+    
+    You can follow the [official installation instructions](https://www.graalvm.org/docs/getting-started-with-graalvm/#install-graalvm) from the GraalVM website.
+    After following the instructions, ensure that you install the Native Image extension installed by running:
+    
+    ```
+    gu install native-image
+    ```
+   
+    Once you finish following the instructions, verify that the default version of Java is set to the Graal version by running `java -version` in a terminal.
+    
+    You will see something similar to the below output:
+    
+    ```
+    $ java -version
+   
+    openjdk version "11.0.7" 2020-04-14
+    OpenJDK Runtime Environment GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02)
+    OpenJDK 64-Bit Server VM GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02, mixed mode, sharing)
+    ```

--- a/google-cloud-graalvm-samples/pubsub-sample/README.md
+++ b/google-cloud-graalvm-samples/pubsub-sample/README.md
@@ -4,38 +4,9 @@ The Pub/Sub sample application demonstrates some common operations with Pub/Sub 
 
 ## Setup Instructions
 
-1. If you have not already, [create a Google Cloud Platform Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project) and [enable the Pub/Sub APIs](https://console.cloud.google.com/apis/api/pubsub.googleapis.com).
+1. Follow the [GCP Project and GraalVM Setup Instructions](../README.md).
 
-2. Install the [Google Cloud SDK](https://cloud.google.com/sdk/) which will allow you to run the sample with your project's credentials.
-
-    Once installed, log in with Application Default Credentials using the following command:
-    
-    ```
-    gcloud auth application-default login
-    ```
-   
-    **Note:** Authenticating with Application Default Credentials is convenient to use during development, but we recommend [alternate methods of authentication](https://cloud.google.com/docs/authentication/production) during production use.
-    
-3. Install the GraalVM compiler.
-    
-    You can follow the [official installation instructions](https://www.graalvm.org/docs/getting-started-with-graalvm/#install-graalvm) from the GraalVM website.
-    After following the instructions, ensure that you install the Native Image extension installed by running:
-    
-    ```
-    gu install native-image
-    ```
-   
-    Once you finish following the instructions, verify that the default version of Java is set to the Graal version by running `java -version` in a terminal.
-    
-    You will see something similar to the below output:
-    
-    ```
-    $ java -version
-   
-    openjdk version "11.0.7" 2020-04-14
-    OpenJDK Runtime Environment GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02)
-    OpenJDK 64-Bit Server VM GraalVM CE 20.1.0 (build 11.0.7+10-jvmci-20.1-b02, mixed mode, sharing)
-    ```
+2. [Enable the Pub/Sub APIs](https://console.cloud.google.com/apis/api/pubsub.googleapis.com).
 
 ### Run with GraalVM Compilation
 

--- a/google-cloud-graalvm-samples/trace-sample/README.md
+++ b/google-cloud-graalvm-samples/trace-sample/README.md
@@ -1,0 +1,39 @@
+# Cloud Trace Client Libraries with GraalVM
+
+This application uses the Google Cloud [Trace Client Libraries](https://github.com/googleapis/java-trace) and can be compiled with GraalVM Native Image.
+
+**Note:** In practice, the Trace Client Libraries are not used directly but through another tool, such as through the [OpenCensus Cloud Trace integration](https://cloud.google.com/trace/docs/setup/java) or through a framework like Spring via [Spring Cloud GCP Trace](https://github.com/spring-cloud/spring-cloud-gcp/blob/master/docs/src/main/asciidoc/trace.adoc).
+
+## Setup Instructions
+
+1. Follow the [GCP Project and GraalVM Setup Instructions](../README.md).
+
+2. Enable the [Cloud Trace APIs](https://console.cloud.google.com/apis/api/cloudtrace.googleapis.com/overview).
+
+## Run with GraalVM Compilation
+
+Navigate to this directory in a new terminal.
+   
+1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
+
+   ```
+   mvn package -P graal
+   ```
+   
+2. Run the application:
+
+   ```
+   ./target/com.example.tracesampleapplication
+   ```
+
+3. The application will generate a new trace and send the data to Cloud Trace where it will be viewable in the [Google Cloud Console Traces Viewer](https://console.cloud.google.com/traces/traces).
+
+    ```
+    Wait some time for the Trace to be populated.
+    Retrieved trace: 1be886734c6a4053adc4346b2b9040c5
+    It has the following spans: 
+    Span: graalvm-trace-sample-test
+    ```
+
+
+

--- a/google-cloud-graalvm-samples/trace-sample/README.md
+++ b/google-cloud-graalvm-samples/trace-sample/README.md
@@ -34,6 +34,3 @@ Navigate to this directory in a new terminal.
     It has the following spans: 
     Span: graalvm-trace-sample-test
     ```
-
-
-


### PR DESCRIPTION
This moves the setup instructions (shared across samples) to the samples-parent README.