### PR TITLE
Increase timeout for graal build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,7 +48,7 @@ jobs:
 
   graal-java-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This should resolve some timeout errors that have occurred: https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/runs/1216958300