### PR TITLE
Add NewLineAtEndOfFile to Checkstyle

### DIFF
--- a/src/checkstyle/custom-checks.xml
+++ b/src/checkstyle/custom-checks.xml
@@ -11,5 +11,5 @@
   <module name="TreeWalker">
     <module name="UnusedImports"/>
   </module>
+  <module name="NewlineAtEndOfFile"/>
 </module>
-


### PR DESCRIPTION
Add the new line to EOF check to our checkstyle.

It seems like the check only gets to applied to Java source files but not onto `pom.xml` files based on our past research here:
https://github.com/spring-cloud/spring-cloud-gcp/issues/338

But at least now our source files will get checked.