### PR TITLE
Upgrade GraalVM version and add samples to CI

### DIFF
--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -1,13 +1,19 @@
 steps:
-  - name: oracle/graalvm-ce:20.1.0-java11
+  - name: oracle/graalvm-ce:20.2.0-java11
     entrypoint: bash
     args: ['./.cloudbuild/graal-build-script.sh']
 
-  - name: oracle/graalvm-ce:20.1.0-java11
+  - name: oracle/graalvm-ce:20.2.0-java11
     args: ['./google-cloud-graalvm-samples/pubsub-sample/target/com.example.pubsubsampleapplication']
 
-  - name: oracle/graalvm-ce:20.1.0-java11
+  - name: oracle/graalvm-ce:20.2.0-java11
     args: ['./google-cloud-graalvm-samples/storage-sample/target/com.example.storagesampleapplication']
+
+  - name: oracle/graalvm-ce:20.2.0-java11
+    args: ['./google-cloud-graalvm-samples/logging-sample/target/com.example.loggingsampleapplication']
+
+  - name: oracle/graalvm-ce:20.2.0-java11
+    args: ['./google-cloud-graalvm-samples/trace-sample/target/com.example.tracesampleapplication']
 
 options:
   # Need to specify a better machine to avoid OOM errors.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up GraalVM Compiler
       uses: rinx/setup-graalvm-ce@v0.0.4
       with:
-        graalvm-version: "20.1.0"
+        graalvm-version: "20.2.0"
         java-version: "java11"
         native-image: "true"
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <graalvm.version>20.1.0</graalvm.version>
+    <graalvm.version>20.2.0</graalvm.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
Upgrades the graalvm compiler version to `20.2.0` for the CI and add missing samples to CI.