### PR TITLE
Make certain native image args shared

### DIFF
--- a/google-cloud-graalvm-samples/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/logging-sample/pom.xml
@@ -89,9 +89,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:+AllowIncompleteClasspath
                 -H:EnableURLProtocols=http,https
-                --report-unsupported-elements-at-runtime
                 --enable-all-security-services
                 -H:+TraceClassInitialization
                 -H:+ReportExceptionStackTraces

--- a/google-cloud-graalvm-samples/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/pubsub-sample/pom.xml
@@ -95,9 +95,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:+AllowIncompleteClasspath
                 -H:EnableURLProtocols=http,https
-                --report-unsupported-elements-at-runtime
                 --enable-all-security-services
                 -H:+TraceClassInitialization
                 -H:+ReportExceptionStackTraces

--- a/google-cloud-graalvm-samples/quarkus-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/quarkus-pubsub-sample/pom.xml
@@ -105,8 +105,6 @@
         <quarkus.package.type>native</quarkus.package.type>
         <!-- We initialize PubSubUtils at runtime since the PROJECT_ID is statically initialized there. -->
         <quarkus.native.additional-build-args>
-          -H:+AllowIncompleteClasspath,\
-          --report-unsupported-elements-at-runtime,\
           -H:+TraceClassInitialization,\
           --initialize-at-run-time=com.example.PubSubUtils
         </quarkus.native.additional-build-args>

--- a/google-cloud-graalvm-samples/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/storage-sample/pom.xml
@@ -94,9 +94,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:+AllowIncompleteClasspath
                 -H:EnableURLProtocols=http,https
-                --report-unsupported-elements-at-runtime
                 --enable-all-security-services
                 -H:+TraceClassInitialization
                 -H:+ReportExceptionStackTraces

--- a/google-cloud-graalvm-samples/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/trace-sample/pom.xml
@@ -94,9 +94,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:+AllowIncompleteClasspath
                 -H:EnableURLProtocols=http,https
-                --report-unsupported-elements-at-runtime
                 --enable-all-security-services
                 -H:+TraceClassInitialization
                 -H:+ReportExceptionStackTraces

--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
@@ -1,4 +1,5 @@
-Args = --initialize-at-build-time=org.conscrypt \
+Args = -H:+AllowIncompleteClasspath --report-unsupported-elements-at-runtime \
+--initialize-at-build-time=org.conscrypt \
 --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
     io.grpc.netty.shaded.io.netty.handler.ssl.OpenSslContext,\
     io.grpc.netty.shaded.io.netty.handler.ssl.ReferenceCountedOpenSslEngine,\


### PR DESCRIPTION
Moves `-H:+AllowIncompleteClasspath` and `--report-unsupported-elements-at-runtime` to be shared as these settings are necessary to get compilation working.