### PR TITLE
Add more coverage for Pub/Sub library calls

### DIFF
--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PubSubSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PubSubSampleApplication.java
@@ -16,18 +16,27 @@
 
 package com.example;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
 import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
-import com.google.protobuf.ByteString;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import com.google.protobuf.FieldMask;
 import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.DeadLetterPolicy;
+import com.google.pubsub.v1.DetachSubscriptionRequest;
+import com.google.pubsub.v1.ProjectName;
 import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
@@ -36,48 +45,71 @@ import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.Topic;
 import com.google.pubsub.v1.TopicName;
+import com.google.pubsub.v1.UpdateSubscriptionRequest;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 public class PubSubSampleApplication {
 
-  private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
 
   /**
    * Driver for the Pub/Sub Sample application which publishes a message to a specified topic.
    */
   public static void main(String[] args) throws Exception {
+    String projectId = ServiceOptions.getDefaultProjectId();
+
     String topicId = "graal-pubsub-test-" + UUID.randomUUID().toString();
-    String subscriptionId = "graal-pubsub-test-sub" + UUID.randomUUID().toString();
+    String pullSubId = "graal-pubsub-test-sub" + UUID.randomUUID().toString();
+    String pushSubId = "graal-pubsub-test-sub" + UUID.randomUUID().toString();
 
     try {
-      createTopic(topicId);
-      createSubscription(subscriptionId, topicId);
+      // Topic management operations
+      createTopic(projectId, topicId);
+      createPullSubscription(projectId, pullSubId, topicId);
+      createPushSubscription(projectId, pushSubId, topicId);
+      detachSubscription(projectId, pushSubId);
+      getTopicPolicy(projectId, topicId);
+      getSubscriptionPolicy(projectId, pullSubId);
+      listSubscriptionInProject(projectId);
+      listSubscriptionInTopic(projectId, topicId);
+      listTopics(projectId);
+      updateSubscriptionDeadLetterTopic(projectId, pushSubId, topicId, topicId);
+      testTopicPermissions(projectId, topicId);
+      testSubscriptionPermissions(projectId, pushSubId);
 
-      publishMessage(topicId);
-      subscribeSync(subscriptionId);
+      // Publish Operations
+      PublishOperations.publishMessage(projectId, topicId);
+      PublishOperations.publishWithBatchSettings(projectId, topicId);
+      PublishOperations.publishWithCustomAttributes(projectId, topicId);
+      PublishOperations.publishWithErrorHandler(projectId, topicId);
+
+      // Receive messages
+      subscribeSync(projectId, pullSubId);
+      receiveMessagesWithDeliveryAttempts(projectId, pullSubId);
     } finally {
-      deleteTopic(topicId);
-      deleteSubscription(subscriptionId);
+      deleteTopic(projectId, topicId);
+      deleteSubscription(projectId, pullSubId);
+      deleteSubscription(projectId, pushSubId);
     }
   }
 
-  private static void createTopic(String topicId) throws IOException {
+  private static void createTopic(String projectId, String topicId) throws IOException {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
-      TopicName topicName = TopicName.of(PROJECT_ID, topicId);
+      TopicName topicName = TopicName.of(projectId, topicId);
       Topic topic = topicAdminClient.createTopic(topicName);
-      System.out.println("Created topic: " + topic.getName() + " under project: " + PROJECT_ID);
+      System.out.println("Created topic: " + topic.getName() + " under project: " + projectId);
     }
   }
 
-  private static void createSubscription(String subscriptionId, String topicId) throws IOException {
+  private static void createPullSubscription(
+      String projectId, String subscriptionId, String topicId) throws IOException {
+
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
-      TopicName topicName = TopicName.of(PROJECT_ID, topicId);
+      TopicName topicName = TopicName.of(projectId, topicId);
       ProjectSubscriptionName subscriptionName =
-          ProjectSubscriptionName.of(PROJECT_ID, subscriptionId);
+          ProjectSubscriptionName.of(projectId, subscriptionId);
       Subscription subscription =
           subscriptionAdminClient.createSubscription(
               subscriptionName, topicName, PushConfig.getDefaultInstance(), 10);
@@ -85,25 +117,132 @@ public class PubSubSampleApplication {
     }
   }
 
-  private static void publishMessage(String topicId) throws Exception {
-    Publisher publisher =
-        Publisher
-            .newBuilder(TopicName.of(PROJECT_ID, topicId))
-            .build();
+  private static void createPushSubscription(
+      String projectId, String subscriptionId, String topicId)
+      throws IOException {
 
-    String message = "Pub/Sub Graal Test published message at timestamp: " + Instant.now();
-    ByteString data = ByteString.copyFromUtf8(message);
-    PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
 
-    publisher.publish(pubsubMessage);
+      // Intentionally set pushEndpoint empty just to exercise API call
+      PushConfig pushConfig = PushConfig.newBuilder().setPushEndpoint("").build();
 
-    ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
-    String messageId = messageIdFuture.get();
-
-    System.out.println("Published message with ID: " + messageId);
+      Subscription subscription =
+          subscriptionAdminClient.createSubscription(subscriptionName, topicName, pushConfig, 10);
+      System.out.println("Created push subscription: " + subscription.getName());
+    }
   }
 
-  private static void subscribeSync(String subscriptionId) throws IOException {
+  private static void detachSubscription(String projectId, String subscriptionId)
+      throws IOException {
+
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.detachSubscription(
+          DetachSubscriptionRequest.newBuilder()
+              .setSubscription(subscriptionName.toString())
+              .build());
+    }
+
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      Subscription subscription = subscriptionAdminClient.getSubscription(subscriptionName);
+      if (subscription.getDetached()) {
+        System.out.println("Subscription is detached.");
+      } else {
+        throw new RuntimeException("Subscription detachment was not successful.");
+      }
+    }
+  }
+
+  private static void getSubscriptionPolicy(String projectId, String subscriptionId)
+      throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(subscriptionName.toString()).build();
+      Policy policy = subscriptionAdminClient.getIamPolicy(getIamPolicyRequest);
+      System.out.println("Subscription policy: " + policy.toString().trim());
+    }
+  }
+
+  private static void getTopicPolicy(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(topicName.toString()).build();
+      Policy policy = topicAdminClient.getIamPolicy(getIamPolicyRequest);
+      System.out.println("Topic policy: " + policy.toString().trim());
+    }
+  }
+
+  private static void listSubscriptionInProject(String projectId) throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectName projectName = ProjectName.of(projectId);
+      int count = 0;
+      for (Subscription subscription :
+          subscriptionAdminClient.listSubscriptions(projectName).iterateAll()) {
+        count += 1;
+      }
+      System.out.println("Subscriptions in project count: " + count);
+    }
+  }
+
+  private static void listSubscriptionInTopic(String projectId, String topicId)
+      throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      int count = 0;
+      for (String subscription : topicAdminClient.listTopicSubscriptions(topicName).iterateAll()) {
+        count += 1;
+      }
+      System.out.println("Subscriptions under topic: " + count);
+    }
+  }
+
+  private static void listTopics(String projectId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      ProjectName projectName = ProjectName.of(projectId);
+      int count = 0;
+      for (Topic topic : topicAdminClient.listTopics(projectName).iterateAll()) {
+        count += 1;
+      }
+      System.out.println("Topic count under project: " + count);
+    }
+  }
+
+  private static void receiveMessagesWithDeliveryAttempts(
+      String projectId, String subscriptionId) {
+
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+    try {
+      subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.println("Successfully started an async message receiver.");
+    } finally {
+      // Shut down the subscriber after 10s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+
+  private static void subscribeSync(String projectId, String subscriptionId) throws IOException {
     SubscriberStubSettings subscriberStubSettings =
         SubscriberStubSettings.newBuilder()
             .setTransportChannelProvider(
@@ -113,7 +252,7 @@ public class PubSubSampleApplication {
             .build();
 
     try (SubscriberStub subscriber = GrpcSubscriberStub.create(subscriberStubSettings)) {
-      String subscriptionName = ProjectSubscriptionName.format(PROJECT_ID, subscriptionId);
+      String subscriptionName = ProjectSubscriptionName.format(projectId, subscriptionId);
       PullRequest pullRequest =
           PullRequest.newBuilder()
               .setMaxMessages(1)
@@ -138,9 +277,95 @@ public class PubSubSampleApplication {
     }
   }
 
-  private static void deleteTopic(String topicId) throws IOException {
+  private static void updateSubscriptionDeadLetterTopic(
+      String projectId, String subscriptionId, String topicId, String deadLetterTopicId)
+      throws IOException {
+
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      TopicName topicName = TopicName.of(projectId, topicId);
+      TopicName deadLetterTopicName = TopicName.of(projectId, deadLetterTopicId);
+
+      DeadLetterPolicy deadLetterPolicy =
+          DeadLetterPolicy.newBuilder()
+              .setDeadLetterTopic(deadLetterTopicName.toString())
+              .setMaxDeliveryAttempts(20)
+              .build();
+
+      Subscription subscription =
+          Subscription.newBuilder()
+              .setName(subscriptionName.toString())
+              .setTopic(topicName.toString())
+              .setDeadLetterPolicy(deadLetterPolicy)
+              .build();
+
+      FieldMask updateMask =
+          FieldMask.newBuilder().addPaths("dead_letter_policy").build();
+
+      UpdateSubscriptionRequest request =
+          UpdateSubscriptionRequest.newBuilder()
+              .setSubscription(subscription)
+              .setUpdateMask(updateMask)
+              .build();
+
+      Subscription response = subscriptionAdminClient.updateSubscription(request);
+      System.out.println("Updated subscription " + response.getName());
+    }
+  }
+
+  private static void testSubscriptionPermissions(String projectId, String subscriptionId)
+      throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      List<String> permissions = new ArrayList<>();
+      permissions.add("pubsub.subscriptions.consume");
+      permissions.add("pubsub.subscriptions.update");
+
+      TestIamPermissionsRequest testIamPermissionsRequest =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(subscriptionName.toString())
+              .addAllPermissions(permissions)
+              .build();
+
+      TestIamPermissionsResponse testedPermissionsResponse =
+          subscriptionAdminClient.testIamPermissions(testIamPermissionsRequest);
+
+      System.out.println("Tested PubSub subscription permissions\n"
+          + testedPermissionsResponse.toString().trim());
+    }
+  }
+
+  private static void testTopicPermissions(String projectId, String topicId)
+      throws IOException {
     try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
-      TopicName topicName = TopicName.of(PROJECT_ID, topicId);
+      ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);
+
+      List<String> permissions = new ArrayList<>();
+      permissions.add("pubsub.topics.attachSubscription");
+      permissions.add("pubsub.topics.publish");
+      permissions.add("pubsub.topics.update");
+
+      TestIamPermissionsRequest testIamPermissionsRequest =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(topicName.toString())
+              .addAllPermissions(permissions)
+              .build();
+
+      TestIamPermissionsResponse testedPermissionsResponse =
+          topicAdminClient.testIamPermissions(testIamPermissionsRequest);
+
+      System.out.println("Tested topic permissions\n"
+          + testedPermissionsResponse.toString().trim());
+    }
+  }
+
+  private static void deleteTopic(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
       try {
         topicAdminClient.deleteTopic(topicName);
         System.out.println("Deleted topic " + topicName);
@@ -150,11 +375,11 @@ public class PubSubSampleApplication {
     }
   }
 
-  private static void deleteSubscription(String subscriptionId)
+  private static void deleteSubscription(String projectId, String subscriptionId)
       throws IOException {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       ProjectSubscriptionName subscriptionName =
-          ProjectSubscriptionName.of(PROJECT_ID, subscriptionId);
+          ProjectSubscriptionName.of(projectId, subscriptionId);
       try {
         subscriptionAdminClient.deleteSubscription(subscriptionName);
         System.out.println("Deleted subscription " + subscriptionName);

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
@@ -33,6 +33,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * Sample methods for Publishing messages to a topic in Pub/Sub.
+ */
 public class PublishOperations {
 
   static void publishMessage(String projectId, String topicId)

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class PublishOperations {
+
+  static void publishMessage(String projectId, String topicId)
+      throws Exception {
+
+    Publisher publisher =
+        Publisher
+            .newBuilder(TopicName.of(projectId, topicId))
+            .build();
+
+    try {
+      String message = "Pub/Sub Graal Test published message at timestamp: " + Instant.now();
+      ByteString data = ByteString.copyFromUtf8(message);
+      PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+
+      publisher.publish(pubsubMessage);
+
+      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+      String messageId = messageIdFuture.get();
+
+      System.out.println("Published message with ID: " + messageId);
+    } finally {
+      publisher.shutdown();
+    }
+  }
+
+  static void publishWithCustomAttributes(
+      String projectId, String topicId) throws Exception {
+
+    TopicName topicName = TopicName.of(projectId, topicId);
+    Publisher publisher = Publisher.newBuilder(topicName).build();
+
+    try {
+      String message = "first message";
+      ByteString data = ByteString.copyFromUtf8(message);
+      PubsubMessage pubsubMessage =
+          PubsubMessage.newBuilder()
+              .setData(data)
+              .putAllAttributes(Collections.singletonMap("year", "2020"))
+              .build();
+
+      // Once published, returns a server-assigned message id (unique within the topic)
+      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+      String messageId = messageIdFuture.get();
+      System.out.println("Published a message with custom attributes: " + messageId);
+    } finally {
+      publisher.shutdown();
+    }
+  }
+
+  static void publishWithBatchSettings(String projectId, String topicId)
+      throws IOException, ExecutionException, InterruptedException {
+
+    TopicName topicName = TopicName.of(projectId, topicId);
+    Publisher publisher = Publisher.newBuilder(topicName).build();
+    List<ApiFuture<String>> messageIdFutures = new ArrayList<>();
+
+    try {
+      // schedule publishing one message at a time : messages get automatically batched
+      for (int i = 0; i < 100; i++) {
+        String message = "message " + i;
+        ByteString data = ByteString.copyFromUtf8(message);
+        PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+
+        // Once published, returns a server-assigned message id (unique within the topic)
+        ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+        messageIdFutures.add(messageIdFuture);
+      }
+    } finally {
+      // Wait on any pending publish requests.
+      List<String> messageIds = ApiFutures.allAsList(messageIdFutures).get();
+      System.out.println("Published " + messageIds.size() + " messages with batch settings.");
+
+      publisher.shutdown();
+    }
+  }
+
+  static void publishWithErrorHandler(
+      String projectId, String topicId) throws IOException {
+
+    TopicName topicName = TopicName.of(projectId, topicId);
+    Publisher publisher = null;
+
+    try {
+      // Create a publisher instance with default settings bound to the topic
+      publisher = Publisher.newBuilder(topicName).build();
+
+      List<String> messages = Arrays.asList("first message", "second message");
+
+      for (final String message : messages) {
+        ByteString data = ByteString.copyFromUtf8(message);
+        PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+
+        // Once published, returns a server-assigned message id (unique within the topic)
+        ApiFuture<String> future = publisher.publish(pubsubMessage);
+
+        // Add an asynchronous callback to handle success / failure
+        ApiFutures.addCallback(
+            future,
+            new ApiFutureCallback<String>() {
+
+              @Override
+              public void onFailure(Throwable throwable) {
+                if (throwable instanceof ApiException) {
+                  ApiException apiException = ((ApiException) throwable);
+                  // details on the API exception
+                  System.out.println(apiException.getStatusCode().getCode());
+                  System.out.println(apiException.isRetryable());
+                }
+                System.out.println("Error publishing message : " + message);
+              }
+
+              @Override
+              public void onSuccess(String messageId) {
+                // Once published, returns server-assigned message ids (unique within the topic)
+                System.out.println("Success Callback: Published message " + messageId);
+              }
+            },
+            MoreExecutors.directExecutor());
+      }
+    } finally {
+      if (publisher != null) {
+        // When finished with the publisher, shutdown to free up resources.
+        publisher.shutdown();
+      }
+    }
+  }
+}

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/PubSubFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/PubSubFeature.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.graalvm.features;
+
+import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassForReflection;
+import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.graalvm.nativeimage.hosted.Feature;
+
+@AutomaticFeature
+public class PubSubFeature implements Feature {
+
+  private static final String PUBSUB_CLASS = "com.google.cloud.pubsub.v1.Publisher";
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    Class<?> pubsubClass = access.findClassByName(PUBSUB_CLASS);
+    if (pubsubClass != null) {
+      registerClassHierarchyForReflection(access, "com.google.iam.v1.Policy");
+      registerClassForReflection(access, "com.google.iam.v1.Binding");
+      registerClassHierarchyForReflection(
+          access, "com.google.iam.v1.TestIamPermissionsResponse");
+    }
+  }
+}

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GoogleJsonClientFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GoogleJsonClientFeature.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.graalvm.features;
+package com.google.cloud.graalvm.features.core;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassForReflection;
 

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.graalvm.features;
+package com.google.cloud.graalvm.features.core;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassForReflection;
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
@@ -76,6 +76,8 @@ public class GrpcNettyFeature implements Feature {
       // Epoll Libraries
       registerClassForReflection(
           access, "io.grpc.netty.shaded.io.netty.channel.epoll.Epoll");
+      registerClassForReflection(
+          access, "io.grpc.netty.shaded.io.netty.channel.epoll.EpollChannelOption");
       registerClassForReflection(
           access, "io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoopGroup");
       registerForReflectiveInstantiation(


### PR DESCRIPTION
Adds more code paths exercised by the Pub/Sub client libraries.

I added all of the snippets found here: https://github.com/googleapis/java-pubsub/tree/master/samples/snippets/src/main/java/pubsub

The code coverage should be much better at this point.