### PR TITLE
Add method for registering classes under package for reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The following Google Cloud Platform client libraries are currently supported:
 
 | Google Cloud Service    | Sample Link              | 
 |-------------------------|--------------------------|
-| [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [google-cloud-graalvm-pubsub-sample](./google-cloud-graalvm-samples/google-cloud-graalvm-pubsub-sample) |
+| [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [pubsub-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample) |
+| [Cloud Storage](https://github.com/googleapis/java-storage) | [storage-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample) |
 
 Additional API compatibility is in active development.
 

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/StorageFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/StorageFeature.java
@@ -18,6 +18,7 @@ package com.google.cloud.graalvm.features;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassForReflection;
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
+import static com.google.cloud.graalvm.features.NativeImageUtils.registerPackageForReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -39,25 +40,11 @@ public class StorageFeature implements Feature {
       registerClassHierarchyForReflection(
           access, "com.google.api.services.storage.model.Bucket");
 
+      registerPackageForReflection(
+          access, "com.google.api.services.storage.model");
+
       registerClassForReflection(
           access, "com.google.api.services.storage.StorageRequest");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.BucketAccessControl");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.BucketAccessControls");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.BucketAccessControl$ProjectTeam");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.ObjectAccessControl");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.ObjectAccessControls");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.ObjectAccessControl$ProjectTeam");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.StorageObject");
-      registerClassForReflection(
-          access, "com.google.api.services.storage.model.StorageObject$Owner");
-
     }
   }
 }


### PR DESCRIPTION
This introduces a utility for scanning classes under a package and registering them for reflection.

All classes under `com.google.api.services.storage.model` need to be registered.

```
registerPackageForReflection(
          access, "com.google.api.services.storage.model");
```

Achieves parity with [storage configs of quarkus extension](https://github.com/quarkiverse/quarkiverse-google-cloud-services/blob/master/storage/deployment/src/main/java/io/quarkiverse/googlecloudservices/storage/deployment/StorageBuildSteps.java).

