### PR TITLE
Downgrade version to 0.1.0-SNAPSHOT

### DIFF
--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -5,17 +5,17 @@ steps:
 
   - name: openjdk:11-jdk
     entrypoint: java
-    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/target/pubsub-sample-1.0.0-SNAPSHOT.jar']
+    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/target/pubsub-sample-0.1.0-SNAPSHOT.jar']
 
   - name: openjdk:11-jdk
     entrypoint: java
-    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/target/storage-sample-1.0.0-SNAPSHOT.jar']
+    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/target/storage-sample-0.1.0-SNAPSHOT.jar']
 
   - name: openjdk:11-jdk
     entrypoint: java
-    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/target/logging-sample-1.0.0-SNAPSHOT.jar']
+    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/target/logging-sample-0.1.0-SNAPSHOT.jar']
 
   - name: openjdk:11-jdk
     entrypoint: java
-    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/target/trace-sample-1.0.0-SNAPSHOT.jar']
+    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/target/trace-sample-0.1.0-SNAPSHOT.jar']
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,8 +43,8 @@ jobs:
     - name: Run Samples
       run: |
         cd google-cloud-graalvm-samples
-        java -jar graalvm-samples-client-library/pubsub-sample/target/pubsub-sample-1.0.0-SNAPSHOT.jar
-        java -jar graalvm-samples-client-library/trace-sample/target/trace-sample-1.0.0-SNAPSHOT.jar
+        java -jar graalvm-samples-client-library/pubsub-sample/target/pubsub-sample-0.1.0-SNAPSHOT.jar
+        java -jar graalvm-samples-client-library/trace-sample/target/trace-sample-0.1.0-SNAPSHOT.jar
 
   graal-java-build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ After adding the snapshots repository, you can add the `google-cloud-graalvm-sup
 <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-graalvm-support</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 </dependency>
 ```
 
@@ -37,7 +37,7 @@ To compile with GraalVM (native-image), ensure the client library version in you
 
 | GraalVM Support version | *`libraries-bom` version | `grpc-netty-shaded` version |
 |-------------------------|:-------------------------|-----------------------------|
-| `1.0.0-SNAPSHOT`        | `>= 11.0.0`              | `>= 1.32.1`                 |
+| `0.1.0-SNAPSHOT`        | `>= 11.0.0`              | `>= 1.32.1`                 |
 
 **NOTE:** Most users typically manage their client library versions using the [Cloud Libraries Bill of Materials](https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM) (`libraries-bom`).
 The `libraries-bom` manages the version of `grpc-netty-shaded` for you as well so you don't have to manage it yourself.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>basic</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-graalvm-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>basic</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>basic</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>basic</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-graalvm-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/README.md
@@ -49,7 +49,7 @@ You may use this method on any machine that supports Docker, but it will produce
 
 ### Running the executable on Linux
 
-You can then execute your native executable with: `./target/quarkus-pubsub-sample-1.0.0-SNAPSHOT-runner`
+You can then execute your native executable with: `./target/quarkus-pubsub-sample-0.1.0-SNAPSHOT-runner`
 
 Then visit http://localhost:8080/ to view the application.
 
@@ -61,7 +61,7 @@ Then you will be able to run the executable in a Linux container.
 ```
 $ export CREDS_PATH=/PATH/TO/CREDS/DIRECTORY/
 $ export CREDS_FILE_NAME=credentials-file.json
-$ docker run -it --rm -v $PWD/target/:/target/ -v $CREDS_PATH:/creds/ --env GOOGLE_APPLICATION_CREDENTIALS=/creds/$CREDS_FILE_NAME -p 8080:8080 ubuntu ./target/quarkus-pubsub-sample-1.0.0-SNAPSHOT-runner
+$ docker run -it --rm -v $PWD/target/:/target/ -v $CREDS_PATH:/creds/ --env GOOGLE_APPLICATION_CREDENTIALS=/creds/$CREDS_FILE_NAME -p 8080:8080 ubuntu ./target/quarkus-pubsub-sample-0.1.0-SNAPSHOT-runner
 ```
 
 If you want to learn more about building native executables, please consult https://quarkus.io/guides/building-native-image.

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>quarkus</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>google-cloud-graalvm-samples</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>spring</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/google-cloud-graalvm-samples/pom.xml
+++ b/google-cloud-graalvm-samples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>google-cloud-graalvm-support-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/google-cloud-graalvm-support/pom.xml
+++ b/google-cloud-graalvm-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>google-cloud-graalvm-support-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-graalvm-support-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
Downgrade version to `0.1.0-SNAPSHOT`.

I'm interested in doing this so I can release an (early-access) version `0.1.0` that can be used by the quarkiverse extension. So users do not have to rely on sonatype snapshots repo.