### PR TITLE
Remove libraries-bom management from the samples

### DIFF
--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -25,18 +25,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>11.0.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
     <plugins>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -31,18 +31,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>11.0.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
     <plugins>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
@@ -25,18 +25,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>11.0.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- These plugins enable building the application with standard JVM. -->
     <plugins>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -30,18 +30,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>11.0.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
     <plugins>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -30,18 +30,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>11.0.0</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
     <plugins>

--- a/google-cloud-graalvm-samples/pom.xml
+++ b/google-cloud-graalvm-samples/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <libraries.bom.version>13.2.0</libraries.bom.version>
+    <libraries.bom.version>16.1.0</libraries.bom.version>
   </properties>
 
   <artifactId>google-cloud-graalvm-samples</artifactId>


### PR DESCRIPTION
I realized that the libraries-bom was already managed in the samples parent, no need to duplicate it in the client-library samples.