### PR TITLE
Simplify sample application arguments

### DIFF
--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -78,10 +78,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
-                --enable-all-security-services
-                -H:+TraceClassInitialization
-                -H:+ReportExceptionStackTraces
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -84,10 +84,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
-                --enable-all-security-services
-                -H:+TraceClassInitialization
-                -H:+ReportExceptionStackTraces
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
@@ -83,6 +83,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
@@ -78,6 +78,7 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -83,10 +83,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
-                --enable-all-security-services
-                -H:+TraceClassInitialization
-                -H:+ReportExceptionStackTraces
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -83,10 +83,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
+                --initialize-at-build-time
                 -H:EnableURLProtocols=http,https
-                --enable-all-security-services
-                -H:+TraceClassInitialization
-                -H:+ReportExceptionStackTraces
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/src/main/java/com/example/TraceSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/src/main/java/com/example/TraceSampleApplication.java
@@ -34,17 +34,16 @@ import java.util.UUID;
  */
 public class TraceSampleApplication {
 
-  private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
-
   /**
    * Runs basic methods in the Trace client libraries.
    */
   public static void main(String[] args) throws IOException, InterruptedException {
+    String projectId = ServiceOptions.getDefaultProjectId();
     TraceServiceClient traceServiceClient = TraceServiceClient.create();
 
     // Create a trace in the current project.
     String traceId = UUID.randomUUID().toString().replaceAll("-", "");
-    PatchTracesRequest createRequest = createPatchTraceRequest(traceId);
+    PatchTracesRequest createRequest = createPatchTraceRequest(traceId, projectId);
     traceServiceClient.patchTraces(createRequest);
 
     // Wait for the trace to be populated in Cloud Trace.
@@ -55,7 +54,7 @@ public class TraceSampleApplication {
       // This checks Cloud trace for the new trace that was just created.
       GetTraceRequest getTraceRequest =
           GetTraceRequest.newBuilder()
-              .setProjectId(PROJECT_ID)
+              .setProjectId(projectId)
               .setTraceId(traceId)
               .build();
 
@@ -74,11 +73,11 @@ public class TraceSampleApplication {
     }
   }
 
-  private static PatchTracesRequest createPatchTraceRequest(String traceId) {
+  private static PatchTracesRequest createPatchTraceRequest(String traceId, String projectId) {
     long currentTime = Instant.now().toEpochMilli() / 1000;
 
     Trace trace = Trace.newBuilder()
-        .setProjectId(PROJECT_ID)
+        .setProjectId(projectId)
         .setTraceId(traceId)
         .addSpans(
             TraceSpan.newBuilder()
@@ -90,7 +89,7 @@ public class TraceSampleApplication {
 
     PatchTracesRequest request =
         PatchTracesRequest.newBuilder()
-            .setProjectId(PROJECT_ID)
+            .setProjectId(projectId)
             .setTraces(Traces.newBuilder().addTraces(trace))
             .build();
 


### PR DESCRIPTION
Remove unnecessary sample application arguments. Also add `--initialize-at-build-time` which is a stricter level of compilation in GraalVM. Quarkus uses `--initialize-at-build-time` by default.