### PR TITLE
Upgrade to GraalVM 20.3.0 and fix GraalVM SDK scope

### DIFF
--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -1,6 +1,6 @@
 steps:
   # Build the sample images
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     entrypoint: bash
     args: ['./.cloudbuild/graal-build-script.sh']
 
@@ -17,35 +17,35 @@ steps:
 
 
   # Run the tests
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/target/com.example.bigquerysampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/target/com.example.pubsubsampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/target/com.example.storagesampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/target/com.example.loggingsampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/target/com.example.secretmanagersampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/target/com.example.tracesampleapplication']
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/target/com.example.firestoresampleapplication']
     env:
       - 'FIRESTORE_EMULATOR_HOST=firestore-emulator:9010'
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/target/com.example.spannersampleapplication']
     env:
       - 'SPANNER_EMULATOR_HOST=spanner-emulator:9010'
 
-  - name: oracle/graalvm-ce:20.2.0-java11
+  - name: oracle/graalvm-ce:20.3.0-java11
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/target/com.example.bigtablesampleapplication']
     env:
       - 'BIGTABLE_EMULATOR_HOST=bigtable-emulator:9010'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set up GraalVM Compiler
       uses: rinx/setup-graalvm-ce@v0.0.5
       with:
-        graalvm-version: "20.2.0"
+        graalvm-version: "20.3.0"
         java-version: "java11"
         native-image: "true"
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
@@ -60,7 +60,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
                 --initialize-at-build-time
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
@@ -59,7 +59,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
@@ -60,7 +60,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
                 --initialize-at-build-time
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -56,7 +56,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -63,7 +63,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
@@ -62,7 +62,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
@@ -57,7 +57,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -62,7 +62,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -61,7 +61,8 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                -H:EnableURLProtocols=http,https
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/pom.xml
@@ -15,7 +15,7 @@
   <artifactId>graalvm-samples-quarkus</artifactId>
 
   <properties>
-    <quarkus.platform.version>1.9.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.10.5.Final</quarkus.platform.version>
   </properties>
 
   <modules>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
@@ -105,7 +105,6 @@
         <quarkus.package.type>native</quarkus.package.type>
         <!-- We initialize PubSubUtils at runtime since the PROJECT_ID is statically initialized there. -->
         <quarkus.native.additional-build-args>
-          -H:+TraceClassInitialization,\
           --initialize-at-run-time=com.example.PubSubUtils
         </quarkus.native.additional-build-args>
       </properties>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
@@ -61,8 +61,8 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                -H:EnableURLProtocols=http,https
-                --enable-all-security-services
+                --enable-https
+                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-support/pom.xml
+++ b/google-cloud-graalvm-support/pom.xml
@@ -16,25 +16,7 @@
       <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>
       <version>${graalvm.version}</version>
-      <exclusions>
-        <!-- These exclusions were added to resolve a Zip-related issue in #58 -->
-        <exclusion>
-          <groupId>org.graalvm.nativeimage</groupId>
-          <artifactId>svm-hosted-native-linux-amd64</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.graalvm.nativeimage</groupId>
-          <artifactId>svm-hosted-native-darwin-amd64</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.graalvm.nativeimage</groupId>
-          <artifactId>svm-hosted-native-windows-amd64</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.graalvm.truffle</groupId>
-          <artifactId>truffle-nfi</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <graalvm.version>20.2.0</graalvm.version>
+    <graalvm.version>20.3.0</graalvm.version>
   </properties>
 
   <name>Google Cloud GraalVM Support Parent</name>


### PR DESCRIPTION
This upgrades the project to using GraalVM 20.3.0.

Also marks the GraalVM SDK dependency as `provided`.

The `provided` correctly excludes the dependency from the compiled sources (so no need for those exclusions anymore) and also fixes the issue with Quarkus mentioned in https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/issues/59.

Fixes https://github.com/GoogleCloudPlatform/google-cloud-graalvm-support/issues/59.