### PR TITLE
Remove 'package' maven step because it's already done in 'install' phase

### DIFF
--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -2,7 +2,7 @@ steps:
   # Build the samples
   - name: openjdk:11-jdk
     entrypoint: bash
-    args: ['./mvnw', 'clean', 'install', 'package', '-B', '-q']
+    args: ['./mvnw', 'clean', 'install', '--batch-mode', '--quiet']
 
 
   # Start emulators


### PR DESCRIPTION
See https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html - `package` is already done in order to satisfy `install`