### PR TITLE
Fix Github Actions build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Setup gcloud
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: latest
         project_id: spring-cloud-gcp-ci
@@ -67,7 +67,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Setup gcloud
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: latest
         project_id: spring-cloud-gcp-ci

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/src/main/java/com/example/DatastoreSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/src/main/java/com/example/DatastoreSampleApplication.java
@@ -94,9 +94,11 @@ public class DatastoreSampleApplication {
               .setNamespace(TEST_NAMESPACE)
               .setKind(TEST_KIND)
               .build();
-      Thread.sleep(1000);
+
       QueryResults<Entity> results = datastore.run(query);
-      System.out.println("Found entity: " + results.next());
+      while (results.hasNext()) {
+        System.out.println("Found entity: " + results.next());
+      }
 
       datastore.delete(key);
       return null;


### PR DESCRIPTION
Fix the Github actions build.

The previous gcloud github action appears to be deprecated, so switching to the new one. Also modify the datastore sample to avoid it flaking when run in the CI.