### PR TITLE
Cloud Tasks sample

### DIFF
--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -44,6 +44,9 @@ steps:
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/target/com.example.secretmanagersampleapplication']
 
   - name: ghcr.io/graalvm/graalvm-ce:java11-20.3.0
+    args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/target/com.example.taskssampleapplication']
+
+  - name: ghcr.io/graalvm/graalvm-ce:java11-20.3.0
     args: ['./google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/target/com.example.tracesampleapplication']
 
   - name: ghcr.io/graalvm/graalvm-ce:java11-20.3.0

--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -69,7 +69,7 @@ steps:
     env:
       - 'DATASTORE_EMULATOR_HOST=http://datastore-emulator:9010'
 
-timeout: 1800s # 30 minutes
+timeout: 3600s # 60 minutes
 options:
   # Need to specify a better machine to avoid OOM errors.
   machineType: 'N1_HIGHCPU_32'

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -55,6 +55,10 @@ steps:
 
   - name: openjdk:11-jdk
     entrypoint: java
+    args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/target/tasks-sample-0.4.0-SNAPSHOT.jar']
+
+  - name: openjdk:11-jdk
+    entrypoint: java
     args: ['-jar', 'google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/target/firestore-sample-0.4.0-SNAPSHOT.jar']
     env:
       - 'FIRESTORE_EMULATOR_HOST=firestore-emulator:9010'

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GraalVM-compatible sample code using various Google Cloud libraries can be found
 | [Cloud Pub/Sub](https://github.com/googleapis/java-pubsub) | [pubsub-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample) |
 | [Cloud Spanner](https://github.com/googleapis/java-spanner) | [spanner-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample) |
 | [Cloud Storage](https://github.com/googleapis/java-storage) | [storage-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample) |
+| [Cloud Tasks](https://github.com/googleapis/java-tasks) | [tasks-sample](./google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample) |
 
 Additional API compatibility is in active development.
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pom.xml
@@ -22,6 +22,7 @@
     <module>logging-sample</module>
     <module>pubsub-sample</module>
     <module>secretmanager-sample</module>
+    <module>tasks-sample</module>
     <module>spanner-sample</module>
     <module>storage-sample</module>
     <module>trace-sample</module>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
@@ -30,5 +30,45 @@ Navigate to this directory in a new terminal.
 3. The application runs through some basic Cloud Tasks operations (create queue, create task) and then prints some results of the operations.
 
     ```
-
+   Test queue ready: name: "projects/xxxxxxxxxx/locations/us-central1/queues/graal-test-queue-4009"
+   rate_limits {
+   max_dispatches_per_second: 500.0
+   max_burst_size: 100
+   max_concurrent_dispatches: 1
+   }
+   retry_config {
+   max_attempts: 100
+   min_backoff {
+   nanos: 100000000
+   }
+   max_backoff {
+   seconds: 3600
+   }
+   max_doublings: 16
+   }
+   state: RUNNING
+   
+   Created task: name: "projects/xxxxxxxxxx/locations/us-central1/queues/graal-test-queue-4009/tasks/5886258204485021611"
+   http_request {
+   url: "https://google.com/"
+   http_method: GET
+   headers {
+   key: "User-Agent"
+   value: "Google-Cloud-Tasks"
+   }
+   }
+   schedule_time {
+   seconds: 1613189391
+   nanos: 486293000
+   }
+   create_time {
+   seconds: 1613189391
+   }
+   dispatch_deadline {
+   seconds: 600
+   }
+   view: BASIC
+   
+   Queue purged
+   Queue deleted
     ```

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
@@ -1,0 +1,34 @@
+# Cloud Tasks Sample Application with GraalVM
+
+The Cloud Tasks sample application demonstrates some common operations with [Google Cloud Tasks](https://cloud.google.com/tasks) and is compatible with GraalVM compilation.
+
+This application will create a new queue called `graal-test-queue` if it does not already exist.
+It will then submit a new task to this queue.
+
+## Setup Instructions
+
+1. Follow the [GCP Project and GraalVM Setup Instructions](../../README.md).
+
+2. [Enable the Cloud Tasks APIs](https://console.cloud.google.com/apis/api/cloudtasks.googleapis.com).
+
+### Run with GraalVM Compilation
+
+Navigate to this directory in a new terminal.
+
+1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
+
+    ```
+    mvn package -P graal
+    ```
+    
+2. Run the application:
+
+    ```
+    ./target/com.example.taskssampleapplication
+    ```
+
+3. The application runs through some basic Cloud Tasks operations (create queue, create task) and then prints some results of the operations.
+
+    ```
+
+    ```

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -39,7 +39,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>com.example.SecretManagerSampleApplication</mainClass>
+              <mainClass>com.example.TasksSampleApplication</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>graalvm-samples-client-library</artifactId>
+    <groupId>com.google.cloud</groupId>
+    <version>0.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>tasks-sample</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-graalvm-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-tasks</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- These plugins enable building the application to a JAR *not* using GraalVM -->
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.example.SecretManagerSampleApplication</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>graal</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>native-image-maven-plugin</artifactId>
+            <version>${graalvm.version}</version>
+            <configuration>
+              <mainClass>com.example.TasksSampleApplication</mainClass>
+              <buildArgs>
+                --no-fallback
+                --no-server
+                --initialize-at-build-time
+                --enable-https
+                --enable-http
+              </buildArgs>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>native-image</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.tasks.v2.*;
+
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Sample application demonstrating GraalVM compatibility with Google Cloud Tasks APIs.
+ */
+public class TasksSampleApplication {
+  /**
+   * Queue name randomness added to avoid
+   * FAILED_PRECONDITION: The queue cannot be created because a queue with this name existed too recently.
+   */
+  private static final String GRAALVM_TEST_QUEUE_NAME = "graal-test-queue-" +
+          new Random().ints(0, 10_000).findAny().getAsInt();
+
+  /**
+   * Runs the Cloud Tasks sample application.
+   */
+  public static void main(String[] args) throws IOException {
+    String projectId = ServiceOptions.getDefaultProjectId();
+    LocationName parent = LocationName.of(projectId, "us-central1");
+    QueueName queueName = QueueName
+            .of(parent.getProject(), parent.getLocation(), GRAALVM_TEST_QUEUE_NAME);
+
+    try (CloudTasksClient client = CloudTasksClient.create()) {
+      Queue queue = Queue.newBuilder()
+              .setName(queueName.toString())
+              .setRateLimits(RateLimits.newBuilder().setMaxConcurrentDispatches(1).build())
+              .build();
+
+      CreateQueueRequest createQueueRequest = CreateQueueRequest.newBuilder()
+              .setParent(parent.toString())
+              .setQueue(queue)
+              .build();
+
+      Queue createdQueue = null;
+      try {
+        createdQueue = client.createQueue(createQueueRequest);
+      } catch (ApiException e) {
+        // If the queue already exists, swallow exception and proceed
+        if(!e.getStatusCode().equals(StatusCode.Code.ALREADY_EXISTS)) {
+          throw e;
+        }
+      }
+      System.out.println("Test queue ready: " + createdQueue);
+
+      // Create task
+      HttpRequest taskTarget = HttpRequest.newBuilder()
+              .setUrl("https://google.com")
+              .setHttpMethod(HttpMethod.GET)
+              .build();
+
+      Task taskRequest = Task.newBuilder()
+              .setHttpRequest(taskTarget)
+              .build();
+      Task task = client.createTask(queueName, taskRequest);
+      System.out.println("Created task: " + task);
+
+      // Cleanup after test
+      client.purgeQueue(queueName);
+      System.out.println("Queue purged");
+
+      client.deleteQueue(queueName);
+      System.out.println("Queue deleted");
+    }
+  }
+
+}

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
@@ -27,7 +27,7 @@ import com.google.cloud.tasks.v2.QueueName;
 import com.google.cloud.tasks.v2.RateLimits;
 import com.google.cloud.tasks.v2.Task;
 import java.io.IOException;
-import java.util.Random;
+import java.util.UUID;
 
 /**
  * Sample application demonstrating GraalVM compatibility with Google Cloud Tasks APIs.
@@ -45,9 +45,12 @@ public class TasksSampleApplication {
    */
   public static void main(String[] args) throws IOException {
     String projectId = ServiceOptions.getDefaultProjectId();
-    LocationName parent = LocationName.of(projectId, "us-central1");
-    QueueName queueName = QueueName.of(parent.getProject(), parent.getLocation(),
-                    GRAALVM_TEST_QUEUE_NAME + getRandomInt());
+    LocationName parent = LocationName.of(projectId, "us-east1");
+    QueueName queueName =
+        QueueName.of(
+            parent.getProject(),
+            parent.getLocation(),
+            GRAALVM_TEST_QUEUE_NAME + UUID.randomUUID().toString());
 
     try (CloudTasksClient client = CloudTasksClient.create()) {
       // Create queue
@@ -83,11 +86,5 @@ public class TasksSampleApplication {
       client.deleteQueue(queueName);
       System.out.println("Queue deleted");
     }
-  }
-
-  static int getRandomInt() {
-    return new Random()
-            .ints(0, 10_000)
-            .findAny().getAsInt();
   }
 }

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/src/main/java/com/example/TasksSampleApplication.java
@@ -16,8 +16,6 @@
 
 package com.example;
 
-import com.google.api.gax.rpc.ApiException;
-import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.tasks.v2.CloudTasksClient;
 import com.google.cloud.tasks.v2.CreateQueueRequest;

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
@@ -33,9 +33,7 @@ public class CloudTasksFeature implements Feature {
   public void beforeAnalysis(BeforeAnalysisAccess access) {
     Class<?> cloudTasksClass = access.findClassByName(CLOUD_TASKS_CLASS);
     if (cloudTasksClass != null) {
-      registerPackageForReflection(
-            access, "com.google.cloud.tasks.v2"
-      );
+      registerPackageForReflection(access, "com.google.cloud.tasks.v2");
     }
   }
 }

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.graalvm.features;
+
+import static com.google.cloud.graalvm.features.NativeImageUtils.registerPackageForReflection;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import org.graalvm.nativeimage.hosted.Feature;
+
+/**
+ * Configures Native Image settings for the Google Cloud Storage client libraries.
+ */
+@AutomaticFeature
+public class CloudTasksFeature implements Feature {
+
+  private static final String CLOUD_TASKS_CLASS = "com.google.cloud.tasks.v2.Task";
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    Class<?> cloudTasksClass = access.findClassByName(CLOUD_TASKS_CLASS);
+    if (cloudTasksClass != null) {
+      // Without this, the toString() model methods don't work
+      registerPackageForReflection(
+            access, "com.google.cloud.tasks.v2"
+      );
+    }
+  }
+}

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/CloudTasksFeature.java
@@ -33,7 +33,6 @@ public class CloudTasksFeature implements Feature {
   public void beforeAnalysis(BeforeAnalysisAccess access) {
     Class<?> cloudTasksClass = access.findClassByName(CLOUD_TASKS_CLASS);
     if (cloudTasksClass != null) {
-      // Without this, the toString() model methods don't work
       registerPackageForReflection(
             access, "com.google.cloud.tasks.v2"
       );

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
@@ -61,7 +61,8 @@ public class GrpcNettyFeature implements Feature {
       // Misc. Google classes
       registerClassHierarchyForReflection(
           access, "com.google.protobuf.DescriptorProtos");
-      registerClassForReflection(access, "com.google.protobuf.Duration");
+      registerClassHierarchyForReflection(access, "com.google.protobuf.Duration");
+      registerClassHierarchyForReflection(access, "com.google.protobuf.Timestamp");
       registerClassForReflection(access, "com.google.api.FieldBehavior");
 
       // Misc. classes used by grpc-netty-shaded


### PR DESCRIPTION
Opening this early to get some feedback. The queue and task creation works flawlessly, but I ran into issues when attempting to convert `Queue` and `Task` classes into strings. 

At runtime, the natively built image would fail complaining about getters not being found, both within the class in question and the builder, for example `Queue$Builder`.  This is, presumably, because the way gRPC classes are converted to strings requires reflective access. For example, the Task object is printed like this:

```
name: "projects/xxxxxxxx/locations/us-central1/queues/graal-test-queue-6685/tasks/56217623861818533241"
http_request {
  url: "https://google.com/"
  http_method: GET
  headers {
    key: "User-Agent"
    value: "Google-Cloud-Tasks"
  }
}
schedule_time {
  seconds: 1613187863
  nanos: 685055000
}
create_time {
  seconds: 1613187863
}
dispatch_deadline {
  seconds: 600
}
view: BASIC
```

As you can see, it also prints some timestamps and durations. Because it uses `com.google.protobuf.Duration` and `com.google.protobuf.Timestamp` classes to represent those values, I also got a runtime crash complaining that the getters for those classes were not available within the corresponding static Builders. 

This is why I changed the `GrpcNettyFeature` to include both and register the whole hierarchy in order to include their static Builder classes.

If you feel that this falls outside the scope of creating a Cloud Tasks sample, let me know. I think it might be worthwhile attempting to print out more of the classes in the other samples and see if same issues apply. Alternatively, if you don't wish to support `toString()` conversions for the classes, I could take this out entirely and just focus on the Tasks sample.