### PR TITLE
Fix JSON language header override method (take 2)

### DIFF
--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
@@ -8,4 +8,5 @@ Args = -H:+AllowIncompleteClasspath --report-unsupported-elements-at-runtime \
     io.grpc.netty.shaded.io.netty.internal.tcnative.SSLPrivateKeyMethod,\
     io.grpc.netty.shaded.io.grpc.netty,\
     io.grpc.netty.shaded.io.netty.channel.epoll,\
-    io.grpc.netty.shaded.io.netty.channel.unix
+    io.grpc.netty.shaded.io.netty.channel.unix,\
+    com.google.api.client.googleapis.services.AbstractGoogleClientRequest$ApiClientVersion


### PR DESCRIPTION
Use an alternate approach for setting the JSON client language headers.

The previous method references classes from `jdk.vm.ci.meta` but this seems to break the Kokoro build. Standard JDK 8 does not seem to have access to classes in this package.