### PR TITLE
Makes the ProtobufMessageFeature optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Typically, you can just depend on the latest versions of the client libraries to
 This is an easy way to ensure that the versions of all the client libraries in your project are compatible with each other and up-to-date.
 The `libraries-bom` also manages the version of `grpc-netty-shaded` as well and ensures that it is at the latest compatible version.
 
+### GraalVM Features
+
+This project offers [GraalVM features](https://www.graalvm.org/sdk/javadoc/index.html?org/graalvm/nativeimage/hosted/Feature.html) which provides optional reflection configurations for specific use-cases.
+These features should only be used when necessary because they increase the size of the container image and increase compilation times.
+
+* `com.google.cloud.graalvm.features.ProtobufMessageFeature`: Adds reflection metadata for request objects of the Google Cloud APIs that your application uses.
+This is typically only needed if you need to print/log requests objects or access them reflectively.
+
+Add the features as an additional build argument to the native-image compiler via the `--features` flag.
+
+Command line Example:
+
+```
+native-image -cp <other settings> --features=com.google.cloud.graalvm.features.ProtobufMessageFeature
+```
+
+The [Cloud Tasks code sample](google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml) demonstrates how to use this setting.
+
 ## Supported Libraries
 
 Most of the Java Google Client Libraries [listed here](https://github.com/googleapis/google-cloud-java#supported-apis) are supported for GraalVM compilation using this dependency.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -65,6 +65,7 @@
                 --initialize-at-build-time
                 --enable-https
                 --enable-http
+                --features=com.google.cloud.graalvm.features.ProtobufMessageFeature
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -64,6 +64,7 @@
                 --initialize-at-build-time
                 --enable-https
                 --enable-http
+                --features=com.google.cloud.graalvm.features.core.ProtobufMessageFeature
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -64,7 +64,7 @@
                 --initialize-at-build-time
                 --enable-https
                 --enable-http
-                --features=com.google.cloud.graalvm.features.core.ProtobufMessageFeature
+                --features=com.google.cloud.graalvm.features.ProtobufMessageFeature
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
@@ -16,7 +16,7 @@
   <artifactId>graalvm-samples-spring</artifactId>
 
   <properties>
-    <spring-boot.version>2.4.4</spring-boot.version>
+    <spring-boot.version>2.4.0-M3</spring-boot.version>
     <spring-cloud-gcp.version>1.2.7.RELEASE</spring-cloud-gcp.version>
   </properties>
 

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/pom.xml
@@ -16,7 +16,7 @@
   <artifactId>graalvm-samples-spring</artifactId>
 
   <properties>
-    <spring-boot.version>2.4.0-M3</spring-boot.version>
+    <spring-boot.version>2.4.4</spring-boot.version>
     <spring-cloud-gcp.version>1.2.7.RELEASE</spring-cloud-gcp.version>
   </properties>
 

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/ProtobufMessageFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/ProtobufMessageFeature.java
@@ -14,26 +14,39 @@
  * limitations under the License.
  */
 
-package com.google.cloud.graalvm.features.core;
+package com.google.cloud.graalvm.features;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.getMethodOrFail;
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 /**
- * A feature which registers reflective usages of the GRPC Protobuf libraries.
+ * A optional feature which registers reflective usages of the GRPC Protobuf libraries.
+ *
+ * <p>This feature is only needed if you need to access proto objects reflectively
+ * (such as printing/logging proto objects).
+ *
+ * <p>To add this feature, add
+ * "--feature com.google.cloud.graalvm.features.ProtobufMessageFeature"
+ * to your GraalVM configuration.
  */
-@AutomaticFeature
 public class ProtobufMessageFeature implements Feature {
 
+  // Proto classes to check on the classpath.
   private static final String PROTO_MESSAGE_CLASS = "com.google.protobuf.GeneratedMessageV3";
   private static final String PROTO_ENUM_CLASS = "com.google.protobuf.ProtocolMessageEnum";
   private static final String ENUM_VAL_DESCRIPTOR_CLASS =
       "com.google.protobuf.Descriptors$EnumValueDescriptor";
+
+  // Prefixes of methods accessed reflectively by
+  // com.google.protobuf.GeneratedMessageV3$ReflectionInvoker
+  private static final List<String> METHOD_ACCESSOR_PREFIXES =
+      Arrays.asList("get", "set", "has", "add", "clear", "newBuilder");
 
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {
@@ -45,12 +58,13 @@ public class ProtobufMessageFeature implements Feature {
       Method internalAccessorMethod =
           getMethodOrFail(protoMessageClass, "internalGetFieldAccessorTable");
 
-      // Finds every class whose `internalGetFieldAccessorTable()` and registers the class.
+      // Finds every class whose `internalGetFieldAccessorTable()` is reached and registers it.
       // `internalGetFieldAccessorTable()` is used downstream to access the class reflectively.
       access.registerMethodOverrideReachabilityHandler(
-          (duringAccess, method) ->
-            registerClassHierarchyForReflection(
-                duringAccess, method.getDeclaringClass().getName()),
+          (duringAccess, method) -> {
+            registerFieldAccessors(method.getDeclaringClass());
+            registerFieldAccessors(getBuilderClass(method.getDeclaringClass()));
+          },
           internalAccessorMethod);
     }
 
@@ -72,5 +86,30 @@ public class ProtobufMessageFeature implements Feature {
           },
           protoEnumClass);
     }
+  }
+
+  /**
+   * Given a proto class, registers the public accessor methods for the provided proto class.
+   */
+  private static void registerFieldAccessors(Class<?> protoClass) {
+    for (Method method : protoClass.getMethods()) {
+      boolean hasAccessorPrefix =
+          METHOD_ACCESSOR_PREFIXES.stream().anyMatch(prefix -> method.getName().startsWith(prefix));
+      if (hasAccessorPrefix) {
+        RuntimeReflection.register(method);
+      }
+    }
+  }
+
+  /**
+   * Given a proto class, returns the Builder nested class.
+   */
+  private static Class<?> getBuilderClass(Class<?> protoClass) {
+    for (Class<?> clazz : protoClass.getClasses()) {
+      if (clazz.getName().endsWith("Builder")) {
+        return clazz;
+      }
+    }
+    return null;
   }
 }

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/ProtobufMessageFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/ProtobufMessageFeature.java
@@ -17,7 +17,6 @@
 package com.google.cloud.graalvm.features;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.getMethodOrFail;
-import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -52,9 +51,6 @@ public class ProtobufMessageFeature implements Feature {
   public void beforeAnalysis(BeforeAnalysisAccess access) {
     Class<?> protoMessageClass = access.findClassByName(PROTO_MESSAGE_CLASS);
     if (protoMessageClass != null) {
-      registerClassHierarchyForReflection(
-          access, "com.google.protobuf.DescriptorProtos");
-
       Method internalAccessorMethod =
           getMethodOrFail(protoMessageClass, "internalGetFieldAccessorTable");
 

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/SpannerFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/SpannerFeature.java
@@ -17,6 +17,7 @@
 package com.google.cloud.graalvm.features;
 
 import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassForReflection;
+import static com.google.cloud.graalvm.features.NativeImageUtils.registerClassHierarchyForReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -33,6 +34,10 @@ public class SpannerFeature implements Feature {
   public void beforeAnalysis(BeforeAnalysisAccess access) {
     Class<?> spannerClass = access.findClassByName(SPANNER_CLASS);
     if (spannerClass != null) {
+      registerClassHierarchyForReflection(
+          access, "com.google.spanner.admin.database.v1.Database");
+      registerClassHierarchyForReflection(
+          access, "com.google.spanner.admin.instance.v1.Instance");
       registerClassForReflection(
           access, "com.google.spanner.admin.database.v1.RestoreInfo");
     }

--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/GrpcNettyFeature.java
@@ -118,9 +118,12 @@ public class GrpcNettyFeature implements Feature {
    * Miscellaneous classes that need to be registered coming from various JARs.
    */
   private static void loadMiscClasses(BeforeAnalysisAccess access) {
+    registerClassHierarchyForReflection(
+        access, "com.google.protobuf.DescriptorProtos");
+    registerClassForReflection(access, "com.google.api.FieldBehavior");
+
     registerForUnsafeFieldAccess(
         access, "javax.net.ssl.SSLContext", "contextSpi");
-
     registerClassForReflection(
         access, "java.lang.management.ManagementFactory");
     registerClassForReflection(


### PR DESCRIPTION
This makes the `ProtobufMessageFeature` opt-in.

It is a good practice to minimize the amount of reflection you register; In the vast majority of cases, you only need to register proto objects for reflection if you want to print/log them.

This has a big impact on the resulting image size; reduces the image size of the [Quarkus sample](https://github.com/quarkiverse/quarkus-google-cloud-services/tree/master/integration-tests) from 150mb to 95mb. Also it reduces the compilation time from ~5 minutes to around 3-4 mins.