### PR TITLE
Exclude installing samples from Kokoro staging step

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -29,7 +29,7 @@ setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
 # Install and run unit tests.
-./mvnw install -B -V
+./mvnw install -B -V -P release
 
 # change to release version
 ./mvnw versions:set -DremoveSnapshot


### PR DESCRIPTION
This adds the `release` profile to the Kokoro staging step.

Adding the profile will exclude the samples from being installed since they are not needed for staging.