### PR TITLE
Remove install step in Kokoro staging job

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -28,9 +28,6 @@ MAVEN_SETTINGS_FILE=$(realpath .)/settings.xml
 setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
-# Install and run unit tests.
-./mvnw install -B -V -P release
-
 # change to release version
 ./mvnw versions:set -DremoveSnapshot
 

--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -29,7 +29,7 @@ setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
 # Install and run unit tests.
-./mvnw install -B -V
+./mvnw install -B -V -P release
 
 # change to release version
 ./mvnw versions:set -DremoveSnapshot


### PR DESCRIPTION
Removes the install step in the Kokoro staging job.

The `install` is not necessary because `mvn deploy` [includes all of the maven lifecycle phases including install](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#a-build-lifecycle-is-made-up-of-phases).