### PR TITLE
Improve Cloud Build Maven Caching

### DIFF
--- a/.cloudbuild/graal-build.yaml
+++ b/.cloudbuild/graal-build.yaml
@@ -1,12 +1,15 @@
 steps:
   # Download maven cache
   - name: 'gcr.io/cloud-builders/gsutil'
+    entrypoint: bash
     args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - 'gs://${_M2_CACHE}/.m2-graal/'
-      - '/root/.m2'
+      - '-c'
+      - |
+        gsutil cp gs://$_M2_CACHE/maven-graalvm.tar .
+        if [ -f "maven-graalvm.tar" ]; then
+            tar -xf maven-graalvm.tar -C /root/.m2
+            rm maven-graalvm.tar
+        fi
 
   # Build the sample images
   - name: ghcr.io/graalvm/graalvm-ce:java11-21.0.0.2
@@ -15,12 +18,12 @@ steps:
 
   # Reupload maven cache to bucket
   - name: 'gcr.io/cloud-builders/gsutil'
+    entrypoint: bash
     args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - '/root/.m2'
-      - 'gs://${_M2_CACHE}/.m2-graal/'
+      - '-c'
+      - |
+        tar -cf maven-graalvm.tar -C /root/.m2 .
+        gsutil cp maven-graalvm.tar gs://$_M2_CACHE
 
   # Start emulators
   - name: 'gcr.io/cloud-builders/docker'

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -9,7 +9,6 @@ steps:
         if [ -f "maven-std.tar" ]; then
             tar -xf maven-std.tar -C /root/.m2
             rm maven-std.tar
-            ls
         fi
 
   # Build the samples
@@ -23,7 +22,7 @@ steps:
     args:
       - '-c'
       - |
-        tar -cvf maven-std.tar -C /root/.m2 .
+        tar -cf maven-std.tar -C /root/.m2 .
         gsutil cp maven-std.tar gs://$_M2_CACHE
 
   # Start emulators

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -1,12 +1,17 @@
 steps:
   # Download maven cache
   - name: 'gcr.io/cloud-builders/gsutil'
-    args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - 'gs://${_M2_CACHE}/.m2-std/'
-      - '/root/.m2'
+      entrypoint: bash
+      args:
+        - '-c'
+        - |
+          gsutil cp gs://$_M2_CACHE/maven.tar .
+          if [ -f "maven.tar" ]; then
+              echo "Extracting archive"
+              tar -xf maven.tar -C /root/.m2
+              rm maven.tar
+              ls
+          fi
 
   # Build the samples
   - name: openjdk:11-jdk
@@ -15,12 +20,12 @@ steps:
 
   # Reupload maven cache to bucket
   - name: 'gcr.io/cloud-builders/gsutil'
-    args:
-      - '-m'
-      - 'rsync'
-      - '-r'
-      - '/root/.m2'
-      - 'gs://${_M2_CACHE}/.m2-std/'
+      entrypoint: bash
+      args:
+        - '-c'
+        - |
+          tar --directory /root/.m2 -cf maven.tar .
+          gsutil cp maven.tar gs://$_M2_CACHE
 
   # Start emulators
   - name: 'gcr.io/cloud-builders/docker'

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -5,12 +5,12 @@ steps:
     args:
       - '-c'
       - |
-        gsutil cp gs://$_M2_CACHE/maven.tar . \
-        if [ -f "maven.tar" ]; then \
-            echo "Extracting archive" \
-            tar -xf maven.tar -C /root/.m2 \
-            rm maven.tar \
-            ls \
+        gsutil cp gs://$_M2_CACHE/maven.tar .
+        if [ -f "maven.tar" ]; then
+            echo "Extracting archive"
+            tar -xf maven.tar -C /root/.m2
+            rm maven.tar
+            ls
         fi
 
   # Build the samples
@@ -24,7 +24,7 @@ steps:
     args:
       - '-c'
       - |
-        tar --directory /root/.m2 -cf maven.tar . \
+        tar --directory /root/.m2 -cf maven.tar .
         gsutil cp maven.tar gs://$_M2_CACHE
 
   # Start emulators

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -23,7 +23,7 @@ steps:
     args:
       - '-c'
       - |
-        tar -C /root/.m2 -cvf maven-std.tar /root/.m2
+        tar -cvf maven-std.tar -C /root/.m2 .
         gsutil cp maven-std.tar gs://$_M2_CACHE
 
   # Start emulators

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -23,7 +23,7 @@ steps:
     args:
       - '-c'
       - |
-        tar -cvf maven-std.tar /root/.m2
+        tar -C /root/.m2 -cvf maven-std.tar /root/.m2
         gsutil cp maven-std.tar gs://$_M2_CACHE
 
   # Start emulators

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -18,7 +18,7 @@ steps:
     entrypoint: bash
     args: ['./mvnw', 'clean', 'install', '--batch-mode', '--quiet']
 
-  # Reupload maven cache to bucket
+  # Reupload maven cache to the bucket
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: bash
     args:

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -15,7 +15,7 @@ steps:
   # Build the samples
   - name: openjdk:11-jdk
     entrypoint: bash
-    args: ['./mvnw', 'clean', 'install', '--batch-mode', '--quiet']
+    args: ['./mvnw', 'clean', 'install', '--batch-mode']
 
   # Reupload maven cache to the bucket
   - name: 'gcr.io/cloud-builders/gsutil'

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -1,17 +1,17 @@
 steps:
   # Download maven cache
   - name: 'gcr.io/cloud-builders/gsutil'
-      entrypoint: bash
-      args:
-        - '-c'
-        - |
-          gsutil cp gs://$_M2_CACHE/maven.tar .
-          if [ -f "maven.tar" ]; then
-              echo "Extracting archive"
-              tar -xf maven.tar -C /root/.m2
-              rm maven.tar
-              ls
-          fi
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        gsutil cp gs://$_M2_CACHE/maven.tar . \
+        if [ -f "maven.tar" ]; then \
+            echo "Extracting archive" \
+            tar -xf maven.tar -C /root/.m2 \
+            rm maven.tar \
+            ls \
+        fi
 
   # Build the samples
   - name: openjdk:11-jdk
@@ -20,12 +20,12 @@ steps:
 
   # Reupload maven cache to bucket
   - name: 'gcr.io/cloud-builders/gsutil'
-      entrypoint: bash
-      args:
-        - '-c'
-        - |
-          tar --directory /root/.m2 -cf maven.tar .
-          gsutil cp maven.tar gs://$_M2_CACHE
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        tar --directory /root/.m2 -cf maven.tar . \
+        gsutil cp maven.tar gs://$_M2_CACHE
 
   # Start emulators
   - name: 'gcr.io/cloud-builders/docker'

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -17,7 +17,7 @@ steps:
     entrypoint: bash
     args: ['./mvnw', 'clean', 'install', '--batch-mode']
 
-  # Reupload maven cache to the bucket
+  # Reupload maven cache to bucket
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: bash
     args:

--- a/.cloudbuild/std-build.yaml
+++ b/.cloudbuild/std-build.yaml
@@ -5,11 +5,10 @@ steps:
     args:
       - '-c'
       - |
-        gsutil cp gs://$_M2_CACHE/maven.tar .
-        if [ -f "maven.tar" ]; then
-            echo "Extracting archive"
-            tar -xf maven.tar -C /root/.m2
-            rm maven.tar
+        gsutil cp gs://$_M2_CACHE/maven-std.tar .
+        if [ -f "maven-std.tar" ]; then
+            tar -xf maven-std.tar -C /root/.m2
+            rm maven-std.tar
             ls
         fi
 
@@ -24,8 +23,8 @@ steps:
     args:
       - '-c'
       - |
-        tar --directory /root/.m2 -cf maven.tar .
-        gsutil cp maven.tar gs://$_M2_CACHE
+        tar -cvf maven-std.tar /root/.m2
+        gsutil cp maven-std.tar gs://$_M2_CACHE
 
   # Start emulators
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
Improves the Cloud Build maven caching.

This proposed method uploads/downloads a cached tar file containing the cache which is much faster than `gsutil` with `rsync`.

Fixes #111.