### PR TITLE
Update profile naming conventions

### DIFF
--- a/.cloudbuild/graal-build-script.sh
+++ b/.cloudbuild/graal-build-script.sh
@@ -2,7 +2,7 @@
 
 gu install native-image
 ./mvnw clean install --batch-mode --quiet
-./mvnw verify --activate-profiles graal \
+./mvnw verify --activate-profiles native \
     --threads 3 \
     --batch-mode \
     --quiet \

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Native Image Compile
       run: |
         mvn clean install -B -q
-        mvn package -P graal -B --file google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample
+        mvn package -P native -B --file google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample
 
     - name: Run Samples
       run: |

--- a/google-cloud-graalvm-samples/README.md
+++ b/google-cloud-graalvm-samples/README.md
@@ -27,7 +27,7 @@ You will need to follow these prerequisite steps in order to run these samples:
     gu install native-image
     ```
    
-    Once you finish following the instructions, verify that the default version of Java is set to the Graal version by running `java -version` in a terminal.
+    Once you finish following the instructions, verify that the default version of Java is set to the GraalVM version by running `java -version` in a terminal.
     
     You will see something similar to the below output:
     

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/README.md
@@ -15,7 +15,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
@@ -48,7 +48,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/README.md
@@ -41,7 +41,7 @@ The application runs through some simple BigTable Client Library operations to d
 1. Navigate to this directory and compile the application with the GraalVM compiler.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
 
 2. **(Optional)** If you're using the emulator, export the `BIGTABLE_EMULATOR_HOST` as an environment variable in your terminal.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
@@ -47,7 +47,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/README.md
@@ -27,7 +27,7 @@ Once installed, run `gu install native-image`.
     OpenJDK 64-Bit Server VM GraalVM CE 21.0.0 (build 11.0.10+8-jvmci-21.0-b06, mixed mode, sharing)
     ```
 
-2. Run `mvn package -P graal` in this directory.
+2. Run `mvn package -P native` in this directory.
 This triggers the native image build.
 The resulting image is outputted to the `target/` directory.
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/pom.xml
@@ -71,7 +71,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/README.md
@@ -30,7 +30,7 @@ The application runs some simple Cloud SQL queries to demonstrate compatibility.
 1. Navigate to this directory and compile the application with the GraalVM compiler.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
 
 2. Run the application. Set the `-Dinstance` property to the instance connection name referenced above.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/pom.xml
@@ -61,7 +61,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/README.md
@@ -24,7 +24,7 @@ This sample runs through some basic operations of creating/deleting entities, ru
 1. Navigate to this directory and compile the application with the GraalVM compiler.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
 
 2. **(Optional)** If you're using the emulator, export the `DATASTORE_EMULATOR_HOST` as an environment variable in your terminal.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/pom.xml
@@ -48,7 +48,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/README.md
@@ -24,7 +24,7 @@ This sample runs through basic operations of creating a new document, running qu
 1. Navigate to this directory and compile the application with the GraalVM compiler.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
 
 2. **(Optional)** If you're using the emulator, export the `FIRESTORE_EMULATOR_HOST` as an environment variable in your terminal.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
@@ -48,7 +48,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/README.md
@@ -15,7 +15,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
    ```
-   mvn package -P graal
+   mvn package -P native
    ```
 
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -43,7 +43,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/README.md
@@ -15,7 +15,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:
@@ -30,7 +30,7 @@ Navigate to this directory in a new terminal.
     Created topic: projects/YOUR_PROJECT_ID/topics/graal-pubsub-test-00e72640-4e36-4aff-84d2-13b7569b2289 under project: YOUR_PROJECT_ID
     Created pull subscription: projects/YOUR_PROJECT_ID/subscriptions/graal-pubsub-test-sub2fb5e3f3-cb26-439b-b88c-9cb0cfca9e45
     Published message with ID: 457327433078420
-    Received Payload: Pub/Sub Graal Test published message at timestamp: 2020-09-23T19:45:42.746514Z
+    Received Payload: Pub/Sub GraalVM Test published message at timestamp: 2020-09-23T19:45:42.746514Z
     Deleted topic projects/YOUR_PROJECT_ID/topics/graal-pubsub-test-00e72640-4e36-4aff-84d2-13b7569b2289
     Deleted subscription projects/YOUR_PROJECT_ID/subscriptions/graal-pubsub-test-sub2fb5e3f3-cb26-439b-b88c-9cb0cfca9e45
     ```

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -50,7 +50,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/src/main/java/com/example/PublishOperations.java
@@ -47,7 +47,7 @@ public class PublishOperations {
             .build();
 
     try {
-      String message = "Pub/Sub Graal Test published message at timestamp: " + Instant.now();
+      String message = "Pub/Sub GraalVM Test published message at timestamp: " + Instant.now();
       ByteString data = ByteString.copyFromUtf8(message);
       PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
 

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/README.md
@@ -18,7 +18,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
@@ -49,7 +49,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/README.md
@@ -24,7 +24,7 @@ The application creates a new Spanner instance and database, and it runs basic o
 1. Navigate to this directory and compile the application with the GraalVM compiler.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
 
 2. **(Optional)** If you're using the emulator, export the `SPANNER_EMULATOR_HOST` as an environment variable in your terminal.

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
@@ -44,7 +44,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/README.md
@@ -15,7 +15,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -49,7 +49,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/README.md
@@ -18,7 +18,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -49,7 +49,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/README.md
@@ -17,7 +17,7 @@ Navigate to this directory in a new terminal.
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
    ```
-   mvn package -P graal
+   mvn package -P native
    ```
    
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -48,7 +48,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-integration-test/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-integration-test/pom.xml
@@ -82,7 +82,7 @@
       <id>native</id>
       <activation>
         <property>
-          <name>graal</name>
+          <name>native</name>
         </property>
       </activation>
       <build>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-integration-test/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-integration-test/pom.xml
@@ -79,7 +79,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <activation>
         <property>
           <name>graal</name>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/README.md
@@ -32,7 +32,7 @@ Then visit http://localhost:8080/ to view the application.
 You can create a native executable using the `graal` profile.
 
 ```
-mvn package -P graal`
+mvn package -P native`
 ```
 
 ### Compiling using Docker container
@@ -40,7 +40,7 @@ mvn package -P graal`
 If you don't have GraalVM installed, you can run the native executable build in a container using the following command.
 
 ```
-mvn package -P graal -Dquarkus.native.container-build=true -Dnative-image.xmx=6g
+mvn package -P native -Dquarkus.native.container-build=true -Dnative-image.xmx=6g
 ```
 
 This method requires Docker Engine to be installed and configured to have at least 6 GB of memory.

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
@@ -78,7 +78,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <activation>
         <property>
           <name>graal</name>

--- a/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-quarkus/quarkus-pubsub-sample/pom.xml
@@ -81,7 +81,7 @@
       <id>native</id>
       <activation>
         <property>
-          <name>graal</name>
+          <name>native</name>
         </property>
       </activation>
       <build>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/README.md
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/README.md
@@ -16,7 +16,7 @@ You can learn more by viewing the [Spring Cloud GCP reference documentation](htt
 1. Compile the application using the GraalVM Compiler. This step may take a few minutes.
 
     ```
-    mvn package -P graal
+    mvn package -P native
     ```
     
 2. Run the application:

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
@@ -49,7 +49,7 @@
 
   <profiles>
     <profile>
-      <id>graal</id>
+      <id>native</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Uses the more idiomatic way of naming the native image profile `native` instead of `graal`. This convention has been adopted by Spring and Quarkus.