### PR TITLE
Fix indicator class for opencensus feature

### DIFF
--- a/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/OpenCensusFeature.java
+++ b/google-cloud-graalvm-support/src/main/java/com/google/cloud/graalvm/features/core/OpenCensusFeature.java
@@ -27,7 +27,7 @@ import org.graalvm.nativeimage.hosted.Feature;
 @AutomaticFeature
 public class OpenCensusFeature implements Feature {
 
-  private static final String OPEN_CENSUS_CLASS = "io.opencensus.tags.Tags";
+  private static final String OPEN_CENSUS_CLASS = "io.opencensus.impl.tags.TagsComponentImpl";
 
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {


### PR DESCRIPTION
Fix the class to check for on the classpath to determine if opencensus is used. Changing it to the concrete implementation class instead of the `Tag` interface since they live in separate libraries.