### PR TITLE
Add release profile to staging script

### DIFF
--- a/.kokoro/stage.sh
+++ b/.kokoro/stage.sh
@@ -29,7 +29,7 @@ setup_environment_secrets
 create_settings_xml_file $MAVEN_SETTINGS_FILE
 
 # change to release version
-./mvnw versions:set -DremoveSnapshot
+./mvnw versions:set -DremoveSnapshot -P release
 
 # stage release
 ./mvnw clean deploy -B \


### PR DESCRIPTION
This adds the `-P release` profile to the `mvn version` command to avoid the samples from being processed by Maven unnecessarily.