### PR TITLE
Enable http and https support by default

### DIFF
--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigquery-sample/pom.xml
@@ -60,8 +60,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
                 --initialize-at-build-time
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/bigtable-sample/pom.xml
@@ -59,8 +59,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-functions-sample/pom.xml
@@ -84,8 +84,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/cloud-sql-sample/pom.xml
@@ -73,8 +73,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
                 <!-- Additional charsets is needed for error logging -->
                 -H:+AddAllCharsets
               </buildArgs>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/datastore-sample/pom.xml
@@ -60,8 +60,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
                 --initialize-at-build-time
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/firestore-sample/pom.xml
@@ -60,8 +60,6 @@
               <buildArgs>
                 --no-fallback
                 --no-server
-                --enable-https
-                --enable-http
                 --initialize-at-build-time
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/logging-sample/pom.xml
@@ -56,8 +56,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/pubsub-sample/pom.xml
@@ -63,8 +63,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
                 --features=com.google.cloud.graalvm.features.ProtobufMessageFeature
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/secretmanager-sample/pom.xml
@@ -62,8 +62,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/spanner-sample/pom.xml
@@ -57,8 +57,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/storage-sample/pom.xml
@@ -62,8 +62,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/tasks-sample/pom.xml
@@ -62,8 +62,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
                 --features=com.google.cloud.graalvm.features.ProtobufMessageFeature
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-client-library/trace-sample/pom.xml
@@ -61,8 +61,6 @@
                 --no-fallback
                 --no-server
                 --initialize-at-build-time
-                --enable-https
-                --enable-http
               </buildArgs>
             </configuration>
             <executions>

--- a/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
+++ b/google-cloud-graalvm-samples/graalvm-samples-spring/spring-cloud-gcp-trace-sample/pom.xml
@@ -89,8 +89,6 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
-                <buildArg>--enable-https</buildArg>
-                <buildArg>--enable-http</buildArg>
                 <buildArg>--trace-class-initialization=org.springframework.util.unit.DataSize</buildArg>
               </buildArgs>
             </configuration>

--- a/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
+++ b/google-cloud-graalvm-support/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-graalvm-support/native-image.properties
@@ -1,4 +1,5 @@
 Args = --allow-incomplete-classpath \
+--enable-url-protocols=https,http \
 --initialize-at-build-time=org.conscrypt \
 --initialize-at-run-time=io.grpc.netty.shaded.io.netty.handler.ssl.OpenSsl,\
     io.grpc.netty.shaded.io.netty.handler.ssl.OpenSslContext,\


### PR DESCRIPTION
This change enables HTTPS support by default (via `--enable-url-protocols=https,http`) since it is required for any application that requires network connectivity (such as connecting to GCP services).

This no longer needs to be set by the end user manually.